### PR TITLE
Add NCCL Communicator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
 CC=${CUDA_HOME}/bin/nvcc
 
 CUDF_CFLAGS=-I${CUDF_HOME}/include -I${THIRD_PARTY_HOME}/include -I${CUB_HOME}
-CUDF_LIBS=-L${CUDF_HOME}/lib -lcudf -lrmm
+CUDF_LIBS=-L${CUDF_HOME}/lib -Xlinker=-rpath,${CUDF_HOME}/lib -lcudf -lrmm
 MPI_CFLAGS=-I${MPI_HOME}/include
 MPI_LIBS=-L${MPI_HOME}/lib -lmpi
 UCX_CFLAGS=`pkg-config --cflags ucx`
 UCX_LIBS=`pkg-config --libs ucx`
 CUDA_CFLAGS=-I${CUDA_HOME}/include -arch=sm_70 --expt-extended-lambda --default-stream per-thread
 CUDA_LIBS=-L${CUDA_HOME}/lib64 -lcuda -lcudart
+NCCL_CFLAGS=-I${NCCL_HOME}/include
+NCCL_LIBS=-L${NCCL_HOME}/lib -lnccl
 
-CFLAGS=-g -std=c++14 ${MPI_CFLAGS} ${CUDA_CFLAGS} ${UCX_CFLAGS} ${CUDF_CFLAGS}
-LDFLAGS=${MPI_LIBS} ${CUDA_LIBS} ${UCX_LIBS} ${CUDF_LIBS}
+CFLAGS=-g -std=c++14 ${NCCL_CFLAGS} ${MPI_CFLAGS} ${CUDA_CFLAGS} ${UCX_CFLAGS} ${CUDF_CFLAGS}
+LDFLAGS=${NCCL_LIBS} ${MPI_LIBS} ${CUDA_LIBS} ${UCX_LIBS} ${CUDF_LIBS}
 
 generate_dataset=generate_dataset/generate_dataset.cuh generate_dataset/nvtx_helper.cuh
 src=src/comm.cuh src/error.cuh src/distribute_table.cuh src/distributed_join.cuh src/generate_table.cuh src/communicator.o

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ For production-quality distributed join implementation, checkout [cuDF's Dask in
 
 This project depends on CUDA, UCX, MPI and cuDF.
 
-To compile, make sure the variables `CUDA_HOME`, `CUDF_HOME`, `MPI_HOME` and `UCX_HOME` are pointing to the installation path of CUDA, cuDF, MPI, and UCX repectively.
+To compile, make sure the variables `CUDA_HOME`, `CUDF_HOME`, `MPI_HOME`, `UCX_HOME` and `NCCL_HOME`
+are pointing to the installation path of CUDA, cuDF, MPI, UCX and NCCL repectively.
 
 [The wiki page](https://github.com/rapidsai/distributed-join/wiki/How-to-compile-and-run-the-code) contains step-by-step instructions for setting up the environment.
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,14 @@ Partition the input tables into (over decomposition factor) * (number of GPUs) b
 used for computation-communication overlap. This argument has to be an integer >= 1. Higher number
 means smaller batch size. `1` means no overlap. Default: `1`.
 
+**--communicator [STR]**
+
+This option can be either "UCX" or "NCCL", which controls what communicator to use. Default: `UCX`.
+
 **--use-buffer-communicator**
 
-If this option is specified, communication goes through a pre-registered staging buffer. This option
-is recommeneded for IB system to reduce registration overhead.
+If this option is specified, UCX communication goes through a pre-registered staging buffer. This
+option is recommeneded for IB system to reduce registration overhead.
 
 ## Running
 

--- a/benchmark/all_to_all.cu
+++ b/benchmark/all_to_all.cu
@@ -18,6 +18,7 @@
 #include <mpi.h>
 #include <iostream>
 #include <string>
+#include <stdexcept>
 #include <cuda_profiler_api.h>
 #include <cstdint>
 #include <rmm/mr/device/per_device_resource.hpp>
@@ -119,7 +120,7 @@ int main(int argc, char *argv[])
         communicator = new NCCLCommunicator;
         communicator->initialize();
     } else {
-        throw "Unknown communicator name";
+        throw std::runtime_error("Unknown communicator name");
     }
 
     /* Warmup if necessary */

--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -48,6 +48,7 @@ static cudf::size_type PROBE_TABLE_NROWS_EACH_RANK = 100'000'000;
 static double SELECTIVITY = 0.3;
 static bool IS_BUILD_TABLE_KEY_UNIQUE = true;
 static int OVER_DECOMPOSITION_FACTOR = 1;
+static std::string COMMUNICATOR_NAME = "UCX";
 static bool USE_BUFFER_COMMUNICATOR = false;
 
 
@@ -82,6 +83,10 @@ void parse_command_line_arguments(int argc, char *argv[])
             OVER_DECOMPOSITION_FACTOR = atoi(argv[iarg + 1]);
         }
 
+        if (!strcmp(argv[iarg], "--communicator")) {
+            COMMUNICATOR_NAME = argv[iarg + 1];
+        }
+
         if (!strcmp(argv[iarg], "--use-buffer-communicator")) {
             USE_BUFFER_COMMUNICATOR = true;
         }
@@ -113,7 +118,9 @@ void report_configuration()
     std::cout << "Selectivity: " << SELECTIVITY << std::endl;
     std::cout << "Keys in build table are unique: " << IS_BUILD_TABLE_KEY_UNIQUE << std::endl;
     std::cout << "Over-decomposition factor: " << OVER_DECOMPOSITION_FACTOR << std::endl;
-    std::cout << "Buffer communicator: " << USE_BUFFER_COMMUNICATOR << std::endl;
+    std::cout << "Communicator: " << COMMUNICATOR_NAME << std::endl;
+    if (COMMUNICATOR_NAME == "UCX")
+        std::cout << "Buffer communicator: " << USE_BUFFER_COMMUNICATOR << std::endl;
     std::cout << "================================" << std::endl;
 }
 
@@ -147,9 +154,15 @@ int main(int argc, char *argv[])
     MPI_CALL( MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank) );
     MPI_CALL( MPI_Comm_size(MPI_COMM_WORLD, &mpi_size) );
 
-    UCXCommunicator* communicator = initialize_ucx_communicator(
-        USE_BUFFER_COMMUNICATOR, 2 * mpi_size, 800'000'000LL / mpi_size - 100'000LL
-    );
+    Communicator* communicator;
+    if (COMMUNICATOR_NAME == "UCX") {
+        communicator = initialize_ucx_communicator(
+            USE_BUFFER_COMMUNICATOR, 2 * mpi_size, 800'000'000LL / mpi_size - 100'000LL
+        );
+    } else if (COMMUNICATOR_NAME == "NCCL") {
+        communicator = new NCCLCommunicator;
+        communicator->initialize();
+    }
 
     /* Generate build table and probe table on each rank */
 
@@ -210,6 +223,8 @@ int main(int argc, char *argv[])
 
     communicator->finalize();
     delete communicator;
+
+    MPI_CALL( MPI_Finalize() );
 
     return 0;
 }

--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
         USE_BUFFER_COMMUNICATOR, 2 * mpi_size, 800'000'000LL / mpi_size - 100'000LL
     );
 
-    /* Generate build table and probe table on each node */
+    /* Generate build table and probe table on each rank */
 
     std::unique_ptr<cudf::table> left;
     std::unique_ptr<cudf::table> right;

--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -163,6 +163,8 @@ int main(int argc, char *argv[])
     } else if (COMMUNICATOR_NAME == "NCCL") {
         communicator = new NCCLCommunicator;
         communicator->initialize();
+    } else {
+        throw std::runtime_error("Unknown communicator name");
     }
 
     /* Generate build table and probe table on each rank */

--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -32,7 +32,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <rmm/mr/device/default_memory_resource.hpp>
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include "../src/topology.cuh"
 #include "../src/communicator.h"
@@ -144,8 +144,9 @@ int main(int argc, char *argv[])
     CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
     const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
 
-    rmm::mr::cnmem_memory_resource cnmem_mr {pool_size};
-    rmm::mr::set_default_resource(&cnmem_mr);
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource();
+    rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr {mr, pool_size, pool_size};
+    rmm::mr::set_default_resource(&pool_mr);
 
     /* Initialize communicator */
 

--- a/src/comm.cuh
+++ b/src/comm.cuh
@@ -150,7 +150,7 @@ recv_data_by_offset(
  *                                 from rank i. Buffers contained in this argument will be freed in this function. Also
  *                                 see 'recv_data_by_offset'.
  * @param[in] bucket_count         Vector with length of number of ranks, where the ith entry represents the the number
- *                                 of elements of received_data[i]. See 'recv_data_by_offset'.
+ *                                 of elements of received_data[i].
  * @param[in] item_size            The size of each element.
  * @param[out] total_count         The number of elements in the merged buffer returned from this function. It is the
  *                                 sum of bucket_count.

--- a/src/comm.cuh
+++ b/src/comm.cuh
@@ -185,7 +185,9 @@ merge_free_received_offset(
         if (!self_free && irank == communicator->mpi_rank)
             continue;
 
-        rmm::mr::get_default_resource()->deallocate(received_data[irank], 0, 0);
+        rmm::mr::get_default_resource()->deallocate(
+            received_data[irank], bucket_count[irank] * item_size
+        );
     }
 
     return merged_data;

--- a/src/comm.cuh
+++ b/src/comm.cuh
@@ -107,7 +107,7 @@ send_data_by_offset(
  * Note: This call should be enclosed by communicator->start() and communicator->stop().
  *
  * @param[out] data         The data received from each rank. This argument does not need to be preallocated, but the
- *                          caller is responsible for freeing this buffer using RMM_FREE. See
+ *                          caller is responsible for freeing this buffer using RMM. See
  *                          'merge_free_received_offset'.
  * @param[in] count         The number of items to be received from each rank.
  * @param[in] item_size     The size of each item. Used for passing to receive function in UCX.

--- a/src/communicator.cu
+++ b/src/communicator.cu
@@ -33,7 +33,6 @@ void Communicator::initialize()
     MPI_CALL( MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank) );
     MPI_CALL( MPI_Comm_size(MPI_COMM_WORLD, &mpi_size) );
     CUDA_RT_CALL( cudaGetDevice(&current_device) );
-    comm_stream = 0;
 }
 
 

--- a/src/communicator.cu
+++ b/src/communicator.cu
@@ -870,16 +870,13 @@ void NCCLCommunicator::send(const void *buf, int64_t count, int element_size, in
     std::size_t aligned_size = (count * element_size + 255) / 256 * 256;
 
     comm_buffers.push_back(
-        rmm::mr::get_current_device_resource()->allocate(aligned_size, cudaStreamDefault));
-    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
+        rmm::mr::get_current_device_resource()->allocate(aligned_size, comm_stream));
     comm_buffer_sizes.push_back(count * element_size);
 
-    CUDA_RT_CALL(
-        cudaMemcpy(comm_buffers.back(), buf, count * element_size, cudaMemcpyDeviceToDevice
+    CUDA_RT_CALL(cudaMemcpyAsync(
+        comm_buffers.back(), buf, count * element_size, cudaMemcpyDeviceToDevice, comm_stream
     ));
-    NCCL_CALL(
-        ncclSend(comm_buffers.back(), aligned_size, ncclChar, dest, nccl_comm, comm_stream)
-    );
+    NCCL_CALL(ncclSend(comm_buffers.back(), aligned_size, ncclChar, dest, nccl_comm, comm_stream));
 }
 
 
@@ -890,8 +887,7 @@ void NCCLCommunicator::recv(void *buf, int64_t count, int element_size, int sour
     recv_buffers.push_back(buf);
     recv_buffer_idx.push_back(comm_buffers.size());
     comm_buffers.push_back(
-        rmm::mr::get_current_device_resource()->allocate(aligned_size, cudaStreamDefault));
-    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
+        rmm::mr::get_current_device_resource()->allocate(aligned_size, comm_stream));
     comm_buffer_sizes.push_back(count * element_size);
 
     NCCL_CALL(
@@ -903,22 +899,22 @@ void NCCLCommunicator::recv(void *buf, int64_t count, int element_size, int sour
 void NCCLCommunicator::stop()
 {
     NCCL_CALL( ncclGroupEnd() );
-    CUDA_RT_CALL( cudaStreamSynchronize(comm_stream) );
 
     for (std::size_t ibuffer = 0; ibuffer < recv_buffers.size(); ibuffer++) {
         std::size_t idx = recv_buffer_idx[ibuffer];
-        CUDA_RT_CALL(cudaMemcpy(
-            recv_buffers[ibuffer], comm_buffers[idx], comm_buffer_sizes[idx], cudaMemcpyDeviceToDevice
+        CUDA_RT_CALL(cudaMemcpyAsync(
+            recv_buffers[ibuffer], comm_buffers[idx], comm_buffer_sizes[idx],
+            cudaMemcpyDeviceToDevice, comm_stream
         ));
     }
 
     for (std::size_t ibuffer = 0; ibuffer < comm_buffers.size(); ibuffer++) {
         std::size_t aligned_size = (comm_buffer_sizes[ibuffer] + 255) / 256 * 256;
         rmm::mr::get_current_device_resource()->deallocate(
-            comm_buffers[ibuffer], aligned_size, cudaStreamDefault);
+            comm_buffers[ibuffer], aligned_size, comm_stream);
     }
 
-    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
+    CUDA_RT_CALL( cudaStreamSynchronize(comm_stream) );
 }
 
 

--- a/src/communicator.cu
+++ b/src/communicator.cu
@@ -57,7 +57,7 @@ void MPILikeCommunicator::stop()
 void MPILikeCommunicator::send(const void *buf, int64_t count, int element_size, int dest)
 {
     pending_requests.push_back(
-        send(buf, count, element_size, dest, -1)
+        send(buf, count, element_size, dest, reserved_tag)
     );
 }
 
@@ -65,7 +65,7 @@ void MPILikeCommunicator::send(const void *buf, int64_t count, int element_size,
 void MPILikeCommunicator::recv(void *buf, int64_t count, int element_size, int source)
 {
     pending_requests.push_back(
-        recv(buf, count, element_size, source, -1)
+        recv(buf, count, element_size, source, reserved_tag)
     );
 }
 
@@ -298,8 +298,6 @@ void UCXCommunicator::finalize()
     ucp_worker_release_address(ucp_worker, ucp_worker_address);
     ucp_worker_destroy(ucp_worker);
     ucp_cleanup(ucp_context);
-
-    MPI_CALL(MPI_Finalize());
 }
 
 

--- a/src/communicator.cu
+++ b/src/communicator.cu
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <iostream>
+#include <stdexcept>
 
 #include <rmm/mr/device/per_device_resource.hpp>
 
@@ -354,7 +355,7 @@ void UCXBufferCommunicator::initialize()
     UCXCommunicator::initialize();
 
     if (mpi_size > 65536) {
-        throw "Ranks > 65536 is not supported due to tag limitation.";
+        throw std::runtime_error("Ranks > 65536 is not supported due to tag limitation");
     }
 
     /* Create priority stream for copying between user buffer and comm buffer. Useful for overlapping. */
@@ -535,7 +536,7 @@ comm_handle_t UCXBufferCommunicator::send(const void *buf, int64_t count, int el
     // Get the communication buffer
     if (buffer_cache.empty()) {
         // TODO: A better way to implement this would print a warning and fallback to normal send.
-        throw "No buffered cache available. Abort.\n";
+        throw std::runtime_error("No buffered cache available");
     }
 
     void *comm_buffer = buffer_cache.front();
@@ -679,7 +680,7 @@ comm_handle_t UCXBufferCommunicator::recv_helper(void **buf, int64_t *count, int
     // Get the communication buffer
     if (buffer_cache.empty()) {
         // TODO: A better way to implement this would print a warning and fallback to normal send.
-        throw "No buffered cache available. Abort.\n";
+        throw std::runtime_error("No buffered cache available");
     }
 
     void *comm_buffer = buffer_cache.front();

--- a/src/communicator.h
+++ b/src/communicator.h
@@ -164,6 +164,8 @@ virtual void waitall(std::vector<comm_handle_t>::const_iterator begin, std::vect
 
 // used for keeping track of the pending requests since the last *start* call
 std::vector<comm_handle_t> pending_requests;
+// tag to use when no tag is explicitly supplied by the user
+static constexpr int reserved_tag {-1};
 
 };
 

--- a/src/communicator.h
+++ b/src/communicator.h
@@ -30,6 +30,8 @@
 class Communicator
 {
 
+// Note: There is no guarantee that communicators will be thread-safe.
+
 public:
 
 /**
@@ -333,5 +335,10 @@ virtual void recv(void *buf, int64_t count, int element_size, int source);
 virtual void finalize();
 
 ncclComm_t nccl_comm;
+std::vector<void *> comm_buffers;  // used for 128-bit alignment
+// used for keeping track of size allocated in comm_buffers
+std::vector<std::size_t> comm_buffer_sizes;
+std::vector<void *> recv_buffers;
+std::vector<std::size_t> recv_buffer_idx;
 
 };

--- a/src/communicator.h
+++ b/src/communicator.h
@@ -80,13 +80,15 @@ virtual void finalize() = 0;
 int mpi_rank;
 int mpi_size;
 int current_device;
-cudaStream_t comm_stream;
 
 };
 
 
 class MPILikeCommunicator : public Communicator
 {
+
+// *MPILikeCommunicator* is an abstract class which implements the behavior of start/stop pairs
+// for communication libraries like MPI or UCX.
 
 // Note: For all tag send/recv operations, -1 is a reserved tag and should not be used
 // TODO: Enforce this assumption by runtime checking.
@@ -334,6 +336,9 @@ virtual void recv(void *buf, int64_t count, int element_size, int source);
 
 virtual void finalize();
 
+// Stream created/destroyed by the communicator object that is used for communication-related
+// kernels/copies
+cudaStream_t comm_stream;
 ncclComm_t nccl_comm;
 std::vector<void *> comm_buffers;  // used for 128-bit alignment
 // used for keeping track of size allocated in comm_buffers

--- a/src/distributed_join.cuh
+++ b/src/distributed_join.cuh
@@ -145,7 +145,7 @@ all_to_all_comm(
 
         communicator->start();
 
-        // commuicate with other ranks
+        // communicate with other ranks
         send_data_by_offset(
             hashed.column(icol).head(), offset, dtype_size, communicator, false
         );

--- a/src/distributed_join.cuh
+++ b/src/distributed_join.cuh
@@ -456,6 +456,11 @@ distributed_inner_join(
             right_buckets[ibatch], right_counts[ibatch], communicator
         );
 
+        if (over_decom_factor == 1) {
+            hashed_left.reset();
+            hashed_right.reset();
+        }
+
         // mark the communication of ibatch as finished.
         // the join thread is safe to start performing local join on ibatch
         flags[ibatch] = true;
@@ -472,8 +477,10 @@ distributed_inner_join(
     inner_join_thread.join();
 
     // hashed left and right tables should not be needed now
-    hashed_left.reset();
-    hashed_right.reset();
+    if (over_decom_factor > 1) {
+        hashed_left.reset();
+        hashed_right.reset();
+    }
 
     /* Merge join results from different batches into a single table */
 

--- a/src/error.cuh
+++ b/src/error.cuh
@@ -58,6 +58,18 @@
 #endif
 
 
+#ifndef NCCL_CALL
+#define NCCL_CALL(call)                                                                            \
+{                                                                                                  \
+    ncclResult_t status = call;                                                                    \
+    if (ncclSuccess != status) {                                                                   \
+        fprintf(stderr, "ERROR: nccl call \"%s\" in line %d of file %s failed with %s.\n",         \
+                        #call, __LINE__, __FILE__, ncclGetErrorString(status));                    \
+    }                                                                                              \
+}
+#endif
+
+
 #define CHECK_ERROR(rtv, expected_value, msg)                                            \
 {                                                                                        \
     if (rtv != expected_value) {                                                         \


### PR DESCRIPTION
This PR intends to

- [x] Add `start` and `stop` to the `Communicator` class so that it is compatible with NCCL's group calls.
- [x] Modify the distributed join algorithm for using the `start`/`stop` API.
- [x] Since NCCL does not support probing, remove the unknown size `recv` from `Communicator` API and the distributed join algorithm.
- [x] Using NCCL to implement `Communicator` interface.
- [x] Test the performance using `NCCLCommunicator`.
- [x] Add NCCL as an option to command line interface

This PR is built on top of #24.