### PR TITLE
Make the repo compatible with the newest RMM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=${CUDA_HOME}/bin/nvcc
 
 CUDF_CFLAGS=-I${CUDF_HOME}/include -I${CUDF_HOME}/include/libcudf/libcudacxx
-CUDF_LIBS=-L${CUDF_HOME}/lib -lcudf -lrmm
+CUDF_LIBS=-L${CUDF_HOME}/lib -Xcompiler \"-Wl,-rpath-link,${CUDF_HOME}/lib\" -lcudf
 MPI_CFLAGS=-I${MPI_HOME}/include
 MPI_LIBS=-L${MPI_HOME}/lib -lmpi
 UCX_CFLAGS=-I${UCX_HOME}/include

--- a/benchmark/all_to_all.cu
+++ b/benchmark/all_to_all.cu
@@ -19,9 +19,9 @@
 #include <iostream>
 #include <cuda_profiler_api.h>
 #include <cstdint>
-#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include "../src/topology.cuh"
 #include "../src/communicator.h"
@@ -99,8 +99,9 @@ int main(int argc, char *argv[])
     CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
     const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
 
-    rmm::mr::cnmem_memory_resource mr {pool_size};
-    rmm::mr::set_default_resource(&mr);
+    rmm::mr::device_memory_resource* current_mr = rmm::mr::get_current_device_resource();
+    rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> mr {
+        current_mr, pool_size, pool_size};
 
     /* Initialize communicator */
 
@@ -123,6 +124,8 @@ int main(int argc, char *argv[])
         for (int irank = 0; irank < mpi_size; irank ++) {
             warmup_send_buffer[irank] = mr.allocate(WARMUP_BUFFER_SIZE, 0);
         }
+
+        CUDA_RT_CALL( cudaStreamSynchronize(0) );
 
         std::vector<comm_handle_t> warmup_send_reqs(mpi_size, nullptr);
         std::vector<comm_handle_t> warmup_recv_reqs(mpi_size, nullptr);
@@ -151,8 +154,8 @@ int main(int argc, char *argv[])
         communicator->waitall(warmup_recv_reqs);
 
         for (int irank = 0; irank < mpi_rank; irank ++) {
-            mr.deallocate(warmup_send_buffer[irank], 0, 0);
-            mr.deallocate(warmup_recv_buffer[irank], 0, 0);
+            mr.deallocate(warmup_send_buffer[irank], WARMUP_BUFFER_SIZE, 0);
+            mr.deallocate(warmup_recv_buffer[irank], WARMUP_BUFFER_SIZE, 0);
         }
     }
 
@@ -164,6 +167,8 @@ int main(int argc, char *argv[])
     for (int irank = 0; irank < mpi_size; irank ++) {
         send_buffer[irank] = mr.allocate(SIZE / mpi_size, 0);
     }
+
+    CUDA_RT_CALL( cudaStreamSynchronize(0) );
 
     std::vector<comm_handle_t> send_reqs(mpi_size, nullptr);
     std::vector<comm_handle_t> recv_reqs(mpi_size, nullptr);
@@ -195,7 +200,7 @@ int main(int argc, char *argv[])
         communicator->waitall(recv_reqs);
 
         for (int irank = 0; irank < mpi_rank; irank ++)
-            mr.deallocate(recv_buffer[irank], 0, 0);
+            mr.deallocate(recv_buffer[irank], SIZE / mpi_size, 0);
     }
 
     double stop = MPI_Wtime();
@@ -210,8 +215,10 @@ int main(int argc, char *argv[])
     /* Cleanup */
 
     for(int irank = 0; irank < mpi_rank; irank++) {
-        mr.deallocate(send_buffer[irank], 0, 0);
+        mr.deallocate(send_buffer[irank], SIZE / mpi_size, 0);
     }
+
+    CUDA_RT_CALL( cudaStreamSynchronize(0) );
 
     communicator->finalize();
     delete communicator;

--- a/benchmark/all_to_all.cu
+++ b/benchmark/all_to_all.cu
@@ -122,10 +122,10 @@ int main(int argc, char *argv[])
         std::vector<void *> warmup_recv_buffer(mpi_size, nullptr);
 
         for (int irank = 0; irank < mpi_size; irank ++) {
-            warmup_send_buffer[irank] = mr.allocate(WARMUP_BUFFER_SIZE, 0);
+            warmup_send_buffer[irank] = mr.allocate(WARMUP_BUFFER_SIZE, cudaStreamDefault);
         }
 
-        CUDA_RT_CALL( cudaStreamSynchronize(0) );
+        CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
 
         std::vector<comm_handle_t> warmup_send_reqs(mpi_size, nullptr);
         std::vector<comm_handle_t> warmup_recv_reqs(mpi_size, nullptr);
@@ -165,10 +165,10 @@ int main(int argc, char *argv[])
     std::vector<void *> recv_buffer(mpi_size, nullptr);
 
     for (int irank = 0; irank < mpi_size; irank ++) {
-        send_buffer[irank] = mr.allocate(SIZE / mpi_size, 0);
+        send_buffer[irank] = mr.allocate(SIZE / mpi_size, cudaStreamDefault);
     }
 
-    CUDA_RT_CALL( cudaStreamSynchronize(0) );
+    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
 
     std::vector<comm_handle_t> send_reqs(mpi_size, nullptr);
     std::vector<comm_handle_t> recv_reqs(mpi_size, nullptr);
@@ -215,10 +215,10 @@ int main(int argc, char *argv[])
     /* Cleanup */
 
     for(int irank = 0; irank < mpi_rank; irank++) {
-        mr.deallocate(send_buffer[irank], SIZE / mpi_size, 0);
+        mr.deallocate(send_buffer[irank], SIZE / mpi_size, cudaStreamDefault);
     }
 
-    CUDA_RT_CALL( cudaStreamSynchronize(0) );
+    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
 
     communicator->finalize();
     delete communicator;

--- a/benchmark/all_to_all.cu
+++ b/benchmark/all_to_all.cu
@@ -154,8 +154,8 @@ int main(int argc, char *argv[])
         communicator->waitall(warmup_recv_reqs);
 
         for (int irank = 0; irank < mpi_rank; irank ++) {
-            mr.deallocate(warmup_send_buffer[irank], WARMUP_BUFFER_SIZE, 0);
-            mr.deallocate(warmup_recv_buffer[irank], WARMUP_BUFFER_SIZE, 0);
+            mr.deallocate(warmup_send_buffer[irank], WARMUP_BUFFER_SIZE, cudaStreamDefault);
+            mr.deallocate(warmup_recv_buffer[irank], WARMUP_BUFFER_SIZE, cudaStreamDefault);
         }
     }
 
@@ -200,7 +200,7 @@ int main(int argc, char *argv[])
         communicator->waitall(recv_reqs);
 
         for (int irank = 0; irank < mpi_rank; irank ++)
-            mr.deallocate(recv_buffer[irank], SIZE / mpi_size, 0);
+            mr.deallocate(recv_buffer[irank], SIZE / mpi_size, cudaStreamDefault);
     }
 
     double stop = MPI_Wtime();

--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -31,8 +31,8 @@
 
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include "../src/topology.cuh"
 #include "../src/communicator.h"
@@ -137,8 +137,9 @@ int main(int argc, char *argv[])
     CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
     const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
 
-    rmm::mr::cnmem_memory_resource cnmem_mr {pool_size};
-    rmm::mr::set_default_resource(&cnmem_mr);
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource();
+    rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr {mr, pool_size, pool_size};
+    rmm::mr::set_current_device_resource(&pool_mr);
 
     /* Initialize communicator */
 

--- a/src/comm.cuh
+++ b/src/comm.cuh
@@ -24,7 +24,7 @@
 
 #include <cudf/types.hpp>
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 #include "communicator.h"
 #include "error.cuh"
@@ -197,8 +197,12 @@ merge_free_received_offset(
         if (!self_free && irank == communicator->mpi_rank)
             continue;
 
-        rmm::mr::get_default_resource()->deallocate(received_data[irank], 0, 0);
+        rmm::mr::get_current_device_resource()->deallocate(
+            received_data[irank], bucket_count[irank] * item_size, 0
+        );
     }
+
+    CUDA_RT_CALL( cudaStreamSynchronize(0) );
 
     return merged_data;
 }

--- a/src/comm.cuh
+++ b/src/comm.cuh
@@ -198,11 +198,11 @@ merge_free_received_offset(
             continue;
 
         rmm::mr::get_current_device_resource()->deallocate(
-            received_data[irank], bucket_count[irank] * item_size, 0
+            received_data[irank], bucket_count[irank] * item_size, cudaStreamDefault
         );
     }
 
-    CUDA_RT_CALL( cudaStreamSynchronize(0) );
+    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
 
     return merged_data;
 }

--- a/src/communicator.cu
+++ b/src/communicator.cu
@@ -21,7 +21,7 @@
 #include <cassert>
 #include <iostream>
 
-#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 #include "communicator.h"
 #include "error.cuh"
@@ -151,7 +151,8 @@ comm_handle_t UCXCommunicator::recv(void **buf, int64_t *count, int element_size
 
     /* Allocate receive buffer */
 
-    *buf = rmm::mr::get_default_resource()->allocate(ucp_probe_info.length, 0);
+    *buf = rmm::mr::get_current_device_resource()->allocate(ucp_probe_info.length, cudaStreamLegacy);
+    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamLegacy) );
 
     /* Received data */
 
@@ -314,7 +315,8 @@ void UCXBufferCommunicator::initialize()
 void UCXBufferCommunicator::setup_cache(int64_t ncaches, int64_t buffer_size)
 {
     comm_buffer_size = buffer_size;
-    cache_start_addr = rmm::mr::get_default_resource()->allocate(comm_buffer_size * ncaches, 0);
+    cache_start_addr = rmm::mr::get_current_device_resource()->allocate(comm_buffer_size * ncaches, 0);
+    CUDA_RT_CALL( cudaStreamSynchronize(0) );
 
     for (int icache = 0; icache < ncaches; icache ++) {
         void *current_buffer = (void *)((char *)cache_start_addr + icache * buffer_size);
@@ -523,9 +525,10 @@ static void recv_handler(void *request, ucs_status_t status,
 
     if (*(info->recv_buffer) == nullptr && *(info->count) > 0) {
         assert(info->ibatch == 0);
-        *(info->recv_buffer) = rmm::mr::get_default_resource()->allocate(
+        *(info->recv_buffer) = rmm::mr::get_current_device_resource()->allocate(
             *(info->count) * element_size, 0
         );
+        CUDA_RT_CALL( cudaStreamSynchronize(0) );
     }
 
     /* Copy data from communication buffer to user buffer for the finished batch */
@@ -749,7 +752,10 @@ void UCXBufferCommunicator::waitall(std::vector<comm_handle_t>::const_iterator b
 
 void UCXBufferCommunicator::finalize()
 {
-    rmm::mr::get_default_resource()->deallocate(cache_start_addr, 0);
+    rmm::mr::get_current_device_resource()->deallocate(
+        cache_start_addr, comm_buffer_size * buffer_cache.size(), 0
+    );
+    CUDA_RT_CALL( cudaStreamSynchronize(0) );
     UCXCommunicator::finalize();
 }
 

--- a/src/distributed_join.cuh
+++ b/src/distributed_join.cuh
@@ -327,12 +327,18 @@ distributed_inner_join(
     vector<cudf::size_type> right_offset;
 
     std::tie(hashed_left, left_offset) = cudf::detail::hash_partition(
-        left, left_on, mpi_size * over_decom_factor
+        left, left_on, mpi_size * over_decom_factor,
+        rmm::mr::get_current_device_resource(),
+        cudaStreamPerThread
     );
 
     std::tie(hashed_right, right_offset) = cudf::detail::hash_partition(
-        right, right_on, mpi_size * over_decom_factor
+        right, right_on, mpi_size * over_decom_factor,
+        rmm::mr::get_current_device_resource(),
+        cudaStreamPerThread
     );
+
+    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamPerThread) );
 
     left_offset.push_back(left.num_rows());
     right_offset.push_back(right.num_rows());

--- a/src/distributed_join.cuh
+++ b/src/distributed_join.cuh
@@ -35,7 +35,7 @@
 #include <cudf/join.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 #include "error.cuh"
 #include "communicator.h"
@@ -218,6 +218,7 @@ inner_join_func(
     rmm::mr::device_memory_resource* mr)
 {
     CUDA_RT_CALL(cudaSetDevice(communicator->current_device));
+    rmm::mr::set_current_device_resource(mr);
 
     std::chrono::time_point<high_resolution_clock> start_time;
     std::chrono::time_point<high_resolution_clock> stop_time;
@@ -375,7 +376,7 @@ distributed_inner_join(
         std::ref(left_buckets), std::ref(left_counts), std::ref(left_dtypes),
         std::ref(right_buckets), std::ref(right_counts), std::ref(right_dtypes),
         std::ref(batch_join_results), left_on, right_on, columns_in_common,
-        std::ref(flags), communicator, report_timing, rmm::mr::get_default_resource()
+        std::ref(flags), communicator, report_timing, rmm::mr::get_current_device_resource()
     );
 
     /* Use the current thread for all-to-all communication */

--- a/test/buffer_communicator.cu
+++ b/test/buffer_communicator.cu
@@ -21,8 +21,8 @@
 #include <mpi.h>
 
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include "../src/topology.cuh"
 #include "../src/communicator.h"
@@ -79,8 +79,9 @@ int main(int argc, char *argv[])
     CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
     const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
 
-    rmm::mr::cnmem_memory_resource mr {pool_size};
-    rmm::mr::set_default_resource(&mr);
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource();
+    rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr {mr, pool_size, pool_size};
+    rmm::mr::set_current_device_resource(&pool_mr);
 
     /* Initialize communicator */
 
@@ -142,10 +143,11 @@ int main(int argc, char *argv[])
 
     for (int irank = 0; irank < mpi_size; irank ++) {
         if (irank != mpi_rank) {
-            rmm::mr::get_default_resource()->deallocate(recv_buf[irank], 0, 0);
+            rmm::mr::get_current_device_resource()->deallocate(recv_buf[irank], COUNT, 0);
         }
     }
 
+    CUDA_RT_CALL( cudaStreamSynchronize(0) );
     communicator->finalize();
     delete communicator;
 

--- a/test/buffer_communicator.cu
+++ b/test/buffer_communicator.cu
@@ -143,11 +143,13 @@ int main(int argc, char *argv[])
 
     for (int irank = 0; irank < mpi_size; irank ++) {
         if (irank != mpi_rank) {
-            rmm::mr::get_current_device_resource()->deallocate(recv_buf[irank], COUNT, 0);
+            rmm::mr::get_current_device_resource()->deallocate(
+                recv_buf[irank], COUNT, cudaStreamDefault
+            );
         }
     }
 
-    CUDA_RT_CALL( cudaStreamSynchronize(0) );
+    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
     communicator->finalize();
     delete communicator;
 

--- a/test/compare_against_shared.cu
+++ b/test/compare_against_shared.cu
@@ -24,8 +24,8 @@
 #include <cudf/join.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/types.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include "../src/topology.cuh"
 #include "../src/communicator.h"
@@ -101,8 +101,9 @@ int main(int argc, char *argv[])
     CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
     const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
 
-    rmm::mr::cnmem_memory_resource mr {pool_size};
-    rmm::mr::set_default_resource(&mr);
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource();
+    rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr {mr, pool_size, pool_size};
+    rmm::mr::set_current_device_resource(&pool_mr);
 
     /* Initialize communicator */
 

--- a/test/prebuild.cu
+++ b/test/prebuild.cu
@@ -26,8 +26,8 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/join.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
 #include <thrust/sequence.h>
 #include <thrust/execution_policy.h>
 
@@ -112,8 +112,9 @@ int main(int argc, char *argv[])
     CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
     const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
 
-    rmm::mr::cnmem_memory_resource mr {pool_size};
-    rmm::mr::set_default_resource(&mr);
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource();
+    rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr {mr, pool_size, pool_size};
+    rmm::mr::set_current_device_resource(&pool_mr);
 
     /* Initialize communicator */
 


### PR DESCRIPTION
This PR intends to make the repo compatible with RMM 0.16. Given that RMM is moved towards header-only, this PR removes linking against `librmm.so`.