### PR TITLE
Decrease device memory usage

### DIFF
--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -50,6 +50,7 @@ static bool IS_BUILD_TABLE_KEY_UNIQUE = true;
 static int OVER_DECOMPOSITION_FACTOR = 1;
 static std::string COMMUNICATOR_NAME = "UCX";
 static bool USE_BUFFER_COMMUNICATOR = false;
+static int64_t COMMUNICATOR_BUFFER_SIZE = 1'600'000'000LL;
 
 
 void parse_command_line_arguments(int argc, char *argv[])
@@ -157,8 +158,11 @@ int main(int argc, char *argv[])
 
     Communicator* communicator;
     if (COMMUNICATOR_NAME == "UCX") {
+        // *2 because buffers are needed for both sends and receives
+        const int num_comm_buffers = 2 * mpi_size;
         communicator = initialize_ucx_communicator(
-            USE_BUFFER_COMMUNICATOR, 2 * mpi_size * 4, 200'000'000LL / mpi_size - 100'000LL
+            USE_BUFFER_COMMUNICATOR, num_comm_buffers,
+            COMMUNICATOR_BUFFER_SIZE / num_comm_buffers - 100'000LL
         );
     } else if (COMMUNICATOR_NAME == "NCCL") {
         communicator = new NCCLCommunicator;

--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
     Communicator* communicator;
     if (COMMUNICATOR_NAME == "UCX") {
         communicator = initialize_ucx_communicator(
-            USE_BUFFER_COMMUNICATOR, 2 * mpi_size, 800'000'000LL / mpi_size - 100'000LL
+            USE_BUFFER_COMMUNICATOR, 2 * mpi_size * 4, 200'000'000LL / mpi_size - 100'000LL
         );
     } else if (COMMUNICATOR_NAME == "NCCL") {
         communicator = new NCCLCommunicator;

--- a/src/comm.cuh
+++ b/src/comm.cuh
@@ -18,13 +18,8 @@
 #define __COMM_CUH
 
 #include <vector>
-#include <ucp/api/ucp.h>
 #include <mpi.h>
-#include <cassert>
-
 #include <cudf/types.hpp>
-#include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
 
 #include "communicator.h"
 #include "error.cuh"

--- a/src/communicator.cu
+++ b/src/communicator.cu
@@ -39,7 +39,6 @@ void Communicator::initialize()
 void MPILikeCommunicator::initialize()
 {
     Communicator::initialize();
-    reserved_tag = 1025;
 }
 
 
@@ -52,11 +51,6 @@ void MPILikeCommunicator::start()
 void MPILikeCommunicator::stop()
 {
     waitall(pending_requests);
-}
-
-void MPILikeCommunicator::use_new_tag()
-{
-    reserved_tag++;
 }
 
 

--- a/src/communicator.cu
+++ b/src/communicator.cu
@@ -39,6 +39,7 @@ void Communicator::initialize()
 void MPILikeCommunicator::initialize()
 {
     Communicator::initialize();
+    reserved_tag = 1025;
 }
 
 
@@ -51,6 +52,11 @@ void MPILikeCommunicator::start()
 void MPILikeCommunicator::stop()
 {
     waitall(pending_requests);
+}
+
+void MPILikeCommunicator::use_new_tag()
+{
+    reserved_tag++;
 }
 
 

--- a/src/communicator.h
+++ b/src/communicator.h
@@ -53,6 +53,12 @@ virtual void start() = 0;
 virtual void stop() = 0;
 
 /**
+ * If the communicator uses tag internally, this method provides a way for the user to get a new tag
+ * to avoid conflicts.
+ */
+virtual void use_new_tag() {};
+
+/**
  * Send data to a remote rank.
  *
  * @param[in] buf           Data buffer to send to remote rank
@@ -90,7 +96,8 @@ class MPILikeCommunicator : public Communicator
 // *MPILikeCommunicator* is an abstract class which implements the behavior of start/stop pairs
 // for communication libraries like MPI or UCX.
 
-// Note: For all tag send/recv operations, -1 is a reserved tag and should not be used
+// Note: For all tag send/recv operations, tags above 1024 are reserved for group send/recv, and
+// should not be used as a user tag.
 // TODO: Enforce this assumption by runtime checking.
 
 public:
@@ -100,6 +107,8 @@ virtual void initialize();
 virtual void start();
 
 virtual void stop();
+
+virtual void use_new_tag();
 
 virtual void send(const void *buf, int64_t count, int element_size, int dest);
 
@@ -168,8 +177,8 @@ virtual void waitall(std::vector<comm_handle_t>::const_iterator begin, std::vect
 
 // used for keeping track of the pending requests since the last *start* call
 std::vector<comm_handle_t> pending_requests;
-// tag to use when no tag is explicitly supplied by the user
-static constexpr int reserved_tag {-1};
+// tag to use for group calls
+int reserved_tag;
 
 };
 

--- a/src/communicator.h
+++ b/src/communicator.h
@@ -53,12 +53,6 @@ virtual void start() = 0;
 virtual void stop() = 0;
 
 /**
- * If the communicator uses tag internally, this method provides a way for the user to get a new tag
- * to avoid conflicts.
- */
-virtual void use_new_tag() {};
-
-/**
  * Send data to a remote rank.
  *
  * @param[in] buf           Data buffer to send to remote rank
@@ -83,6 +77,12 @@ virtual void recv(void *buf, int64_t count, int element_size, int source) = 0;
  */
 virtual void finalize() = 0;
 
+/**
+ * Whether the distributed join implementation using this communicator should group by batch or
+ * group by column.
+ */
+virtual bool group_by_batch() = 0;
+
 int mpi_rank;
 int mpi_size;
 int current_device;
@@ -96,8 +96,7 @@ class MPILikeCommunicator : public Communicator
 // *MPILikeCommunicator* is an abstract class which implements the behavior of start/stop pairs
 // for communication libraries like MPI or UCX.
 
-// Note: For all tag send/recv operations, tags above 1024 are reserved for group send/recv, and
-// should not be used as a user tag.
+// Note: For all tag send/recv operations, -1 is reserved and should not be used as a user tag.
 // TODO: Enforce this assumption by runtime checking.
 
 public:
@@ -107,8 +106,6 @@ virtual void initialize();
 virtual void start();
 
 virtual void stop();
-
-virtual void use_new_tag();
 
 virtual void send(const void *buf, int64_t count, int element_size, int dest);
 
@@ -178,7 +175,7 @@ virtual void waitall(std::vector<comm_handle_t>::const_iterator begin, std::vect
 // used for keeping track of the pending requests since the last *start* call
 std::vector<comm_handle_t> pending_requests;
 // tag to use for group calls
-int reserved_tag;
+static constexpr int reserved_tag {-1};
 
 };
 
@@ -198,6 +195,7 @@ virtual void wait(comm_handle_t request);
 virtual void waitall(std::vector<comm_handle_t> requests);
 virtual void waitall(std::vector<comm_handle_t>::const_iterator begin, std::vector<comm_handle_t>::const_iterator end);
 virtual void finalize();
+virtual bool group_by_batch() { return true; }
 
 ucp_context_h         ucp_context;
 ucp_worker_h          ucp_worker;
@@ -244,6 +242,10 @@ virtual void wait(comm_handle_t request);
 virtual void waitall(std::vector<comm_handle_t> requests);
 virtual void waitall(std::vector<comm_handle_t>::const_iterator begin, std::vector<comm_handle_t>::const_iterator end);
 virtual void finalize();
+// It is possible to use different tags to distinguish between different messages destined to the
+// same remote GPU, but grouping by batch means more communication buffers are needed, which makes
+// each communication buffer smaller, resulting in a performance degradation.
+virtual bool group_by_batch() { return false; }
 
 enum CommInfoTypes { SEND, RECV };
 
@@ -344,6 +346,10 @@ virtual void send(const void *buf, int64_t count, int element_size, int dest);
 virtual void recv(void *buf, int64_t count, int element_size, int source);
 
 virtual void finalize();
+
+// NCCL does not support sending multiple messages to the same remote GPUs within `start` and `stop`
+// as of V2.7. This feature is planned for V2.8.
+virtual bool group_by_batch() { return false; }
 
 // Stream created/destroyed by the communicator object that is used for communication-related
 // kernels/copies

--- a/src/distribute_table.cuh
+++ b/src/distribute_table.cuh
@@ -179,6 +179,8 @@ distribute_table(
         local_table.push_back(std::move(new_column));
     }
 
+    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
+
     /* Send table from the root rank to all ranks */
 
     for (int icol = 0; icol < ncols; icol++) {
@@ -244,6 +246,8 @@ collect_tables(
                 cudf::make_numeric_column(table.column(icol).type(), table_nrows_scan.back())
             ));
         }
+
+        CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
     }
 
     /* Send table from each rank to root */

--- a/src/error.cuh
+++ b/src/error.cuh
@@ -25,9 +25,11 @@
 #define CUDA_RT_CALL(call)                                                                         \
 {                                                                                                  \
     cudaError_t cudaStatus = call;                                                                 \
-    if (cudaSuccess != cudaStatus)                                                                 \
+    if (cudaSuccess != cudaStatus) {                                                               \
         fprintf(stderr, "ERROR: CUDA RT call \"%s\" in line %d of file %s failed with %s (%d).\n", \
                         #call, __LINE__, __FILE__, cudaGetErrorString(cudaStatus), cudaStatus);    \
+        exit(1);                                                                                   \
+    }                                                                                              \
 }
 #endif
 
@@ -36,9 +38,11 @@
 #define UCX_CALL(call)                                                                             \
 {                                                                                                  \
     ucs_status_t status = call;                                                                    \
-    if (UCS_OK != status)                                                                          \
+    if (UCS_OK != status) {                                                                        \
         fprintf(stderr, "\"%s\" in line %d of file %s failed with %s (%d).\n",                     \
                         #call, __LINE__, __FILE__, ucs_status_string(status), status);             \
+        exit(1);                                                                                   \
+    }                                                                                              \
 }
 #endif
 
@@ -53,6 +57,7 @@
         MPI_Error_string(status, estring, &len);                                                   \
         fprintf(stderr, "\"%s\" in line %d of file %s failed with %s (%d).\n",                     \
                 #call, __LINE__, __FILE__, estring, status);                                       \
+        exit(1);                                                                                   \
     }                                                                                              \
 }
 #endif
@@ -65,6 +70,7 @@
     if (ncclSuccess != status) {                                                                   \
         fprintf(stderr, "ERROR: nccl call \"%s\" in line %d of file %s failed with %s.\n",         \
                         #call, __LINE__, __FILE__, ncclGetErrorString(status));                    \
+        exit(1);                                                                                   \
     }                                                                                              \
 }
 #endif

--- a/src/generate_table.cuh
+++ b/src/generate_table.cuh
@@ -237,7 +237,8 @@ generate_tables_distributed(
 
     // Send each bucket to the desired target rank
 
-    communicator->start();
+    if (communicator->group_by_batch())
+        communicator->start();
 
     all_to_all_comm(
         pre_shuffle_build_table->view(), build_table->mutable_view(),
@@ -249,7 +250,8 @@ generate_tables_distributed(
         probe_table_offset, probe_table_recv_offset, communicator
     );
 
-    communicator->stop();
+    if (communicator->group_by_batch())
+        communicator->stop();
 
     return std::make_pair(std::move(build_table), std::move(probe_table));
 }

--- a/src/generate_table.cuh
+++ b/src/generate_table.cuh
@@ -209,11 +209,11 @@ generate_tables_distributed(
 
     // Send each bucket to the desired target rank
 
-    std::unique_ptr<table> build_table = all_to_all_comm_single_batch(
+    std::unique_ptr<table> build_table = all_to_all_comm(
         pre_shuffle_build_table->view(), build_table_offset, communicator
     );
 
-    std::unique_ptr<table> probe_table = all_to_all_comm_single_batch(
+    std::unique_ptr<table> probe_table = all_to_all_comm(
         pre_shuffle_probe_table->view(), probe_table_offset, communicator
     );
 

--- a/test/prebuild.cu
+++ b/test/prebuild.cu
@@ -124,7 +124,8 @@ int main(int argc, char *argv[])
     MPI_CALL( MPI_Comm_size(MPI_COMM_WORLD, &mpi_size) );
 
     UCXCommunicator* communicator = initialize_ucx_communicator(
-        true, 2 * mpi_size * 4, 100'000LL
+        // *2 because buffers are needed for both sends and receives
+        true, 2 * mpi_size, 100'000LL
     );
 
     /* Generate input tables */

--- a/test/prebuild.cu
+++ b/test/prebuild.cu
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
     MPI_CALL( MPI_Comm_size(MPI_COMM_WORLD, &mpi_size) );
 
     UCXCommunicator* communicator = initialize_ucx_communicator(
-        true, 2 * mpi_size, 100'000LL
+        true, 2 * mpi_size * 4, 100'000LL
     );
 
     /* Generate input tables */
@@ -140,6 +140,8 @@ int main(int argc, char *argv[])
 
         left_view = left_table->view();
         right_view = right_table->view();
+
+        CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
     }
 
     /* Distribute input tables among ranks */


### PR DESCRIPTION
The main purpose of this PR is to decrease device memory usage. Prior to this PR, data received from all-to-all communication from different ranks are kept in separate buffers and then merged together. These buffers take unnecessary device memory usage. In this PR, the received table is allocated before the all-to-all, and the communication writes to this table directly.

In the meantime, this PR also refactors code and fixes a bug that deallocate hashed table too soon currently in the main branch. 