### PR TITLE
Standardize code formatting with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,156 @@
+---
+# This file is copied from cuDF repo.
+# Refer to the following link for the explanation of each params:
+#   http://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+Language: Cpp
+# BasedOnStyle: Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+# This is deprecated
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments:  false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:            false
+  AfterControlStatement: false
+  AfterEnum:             false
+  AfterFunction:         false
+  AfterNamespace:        false
+  AfterObjCDeclaration:  false
+  AfterStruct:           false
+  AfterUnion:            false
+  AfterExternBlock:      false
+  BeforeCatch:           false
+  BeforeElse:            false
+  IndentBraces:          false
+  # disabling the below splits, else, they'll just add to the vertical length of source files!
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: WebKit
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+# Kept the below 2 to be the same as `IndentWidth` to keep everything uniform
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language: Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+  - Language: TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle: google
+# Enabling comment reflow causes doxygen comments to be messed up in their formats!
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+# Be consistent with indent-width, even for people who use tab for indentation!
+TabWidth: 2
+UseTab: Never

--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 ---
-# This file is copied from cuDF repo.
+# This file is copied from cuDF repo:
+#   https://github.com/rapidsai/cudf/blob/branch-0.17/cpp/.clang-format
 # Refer to the following link for the explanation of each params:
 #   http://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 Language: Cpp

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=${CUDA_HOME}/bin/nvcc
 
 CUDF_CFLAGS=-I${CUDF_HOME}/include -I${CUDF_HOME}/include/libcudf/libcudacxx
-CUDF_LIBS=-L${CUDF_HOME}/lib -Xcompiler \"-Wl,-rpath-link,${CUDF_HOME}/lib\" -lcudf
+CUDF_LIBS=-L${CUDF_HOME}/lib -Xcompiler \"-Wl,-rpath-link,${CUDF_HOME}/lib\" -lcudf -lcudf_base -lcudf_join -lcudf_hash -lcudf_partitioning
 MPI_CFLAGS=-I${MPI_HOME}/include
 MPI_LIBS=-L${MPI_HOME}/lib -lmpi
 UCX_CFLAGS=-I${UCX_HOME}/include

--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -14,261 +14,248 @@
  * limitations under the License.
  */
 
-#include <iostream>
-#include <vector>
 #include <algorithm>
-#include <memory>
-#include <utility>
-#include <tuple>
-#include <string>
-#include <stdexcept>
 #include <cstdint>
-#include <cstring>
 #include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
-#include <mpi.h>
 #include <cuda_profiler_api.h>
+#include <mpi.h>
 
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
-#include "../src/topology.cuh"
 #include "../src/communicator.h"
+#include "../src/distributed_join.cuh"
 #include "../src/error.cuh"
 #include "../src/generate_table.cuh"
-#include "../src/distributed_join.cuh"
 #include "../src/registered_memory_resource.hpp"
+#include "../src/topology.cuh"
 
-static std::string key_type = "int64_t";
+static std::string key_type     = "int64_t";
 static std::string payload_type = "int64_t";
 
 static cudf::size_type BUILD_TABLE_NROWS_EACH_RANK = 100'000'000;
 static cudf::size_type PROBE_TABLE_NROWS_EACH_RANK = 100'000'000;
-static double SELECTIVITY = 0.3;
-static bool IS_BUILD_TABLE_KEY_UNIQUE = true;
-static int OVER_DECOMPOSITION_FACTOR = 1;
-static std::string COMMUNICATOR_NAME = "UCX";
-static bool USE_BUFFER_COMMUNICATOR = false;
-static int64_t COMMUNICATOR_BUFFER_SIZE = 1'600'000'000LL;
-
+static double SELECTIVITY                          = 0.3;
+static bool IS_BUILD_TABLE_KEY_UNIQUE              = true;
+static int OVER_DECOMPOSITION_FACTOR               = 1;
+static std::string COMMUNICATOR_NAME               = "UCX";
+static bool USE_BUFFER_COMMUNICATOR                = false;
+static int64_t COMMUNICATOR_BUFFER_SIZE            = 1'600'000'000LL;
 
 void parse_command_line_arguments(int argc, char *argv[])
 {
-    for (int iarg = 0; iarg < argc; iarg++) {
-        if (!strcmp(argv[iarg], "--key-type")) {
-            key_type = argv[iarg + 1];
-        }
+  for (int iarg = 0; iarg < argc; iarg++) {
+    if (!strcmp(argv[iarg], "--key-type")) { key_type = argv[iarg + 1]; }
 
-        if (!strcmp(argv[iarg], "--payload-type")) {
-            payload_type = argv[iarg + 1];
-        }
+    if (!strcmp(argv[iarg], "--payload-type")) { payload_type = argv[iarg + 1]; }
 
-        if (!strcmp(argv[iarg], "--build-table-nrows")) {
-            BUILD_TABLE_NROWS_EACH_RANK = atoi(argv[iarg + 1]);
-        }
-
-        if (!strcmp(argv[iarg], "--probe-table-nrows")) {
-            PROBE_TABLE_NROWS_EACH_RANK = atoi(argv[iarg + 1]);
-        }
-
-        if (!strcmp(argv[iarg], "--selectivity")) {
-            SELECTIVITY = atof(argv[iarg + 1]);
-        }
-
-        if (!strcmp(argv[iarg], "--duplicate-build-keys")) {
-            IS_BUILD_TABLE_KEY_UNIQUE = false;
-        }
-
-        if (!strcmp(argv[iarg], "--over-decomposition-factor")) {
-            OVER_DECOMPOSITION_FACTOR = atoi(argv[iarg + 1]);
-        }
-
-        if (!strcmp(argv[iarg], "--communicator")) {
-            COMMUNICATOR_NAME = argv[iarg + 1];
-        }
-
-        if (!strcmp(argv[iarg], "--use-buffer-communicator")) {
-            USE_BUFFER_COMMUNICATOR = true;
-        }
+    if (!strcmp(argv[iarg], "--build-table-nrows")) {
+      BUILD_TABLE_NROWS_EACH_RANK = atoi(argv[iarg + 1]);
     }
-}
 
+    if (!strcmp(argv[iarg], "--probe-table-nrows")) {
+      PROBE_TABLE_NROWS_EACH_RANK = atoi(argv[iarg + 1]);
+    }
+
+    if (!strcmp(argv[iarg], "--selectivity")) { SELECTIVITY = atof(argv[iarg + 1]); }
+
+    if (!strcmp(argv[iarg], "--duplicate-build-keys")) { IS_BUILD_TABLE_KEY_UNIQUE = false; }
+
+    if (!strcmp(argv[iarg], "--over-decomposition-factor")) {
+      OVER_DECOMPOSITION_FACTOR = atoi(argv[iarg + 1]);
+    }
+
+    if (!strcmp(argv[iarg], "--communicator")) { COMMUNICATOR_NAME = argv[iarg + 1]; }
+
+    if (!strcmp(argv[iarg], "--use-buffer-communicator")) { USE_BUFFER_COMMUNICATOR = true; }
+  }
+}
 
 void report_configuration()
 {
-    MPI_CALL( MPI_Barrier(MPI_COMM_WORLD) );
+  MPI_CALL(MPI_Barrier(MPI_COMM_WORLD));
 
-    int mpi_rank;
-    int mpi_size;
-    MPI_CALL( MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank) );
-    MPI_CALL( MPI_Comm_size(MPI_COMM_WORLD, &mpi_size) );
-    if (mpi_rank != 0)
-        return;
+  int mpi_rank;
+  int mpi_size;
+  MPI_CALL(MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank));
+  MPI_CALL(MPI_Comm_size(MPI_COMM_WORLD, &mpi_size));
+  if (mpi_rank != 0) return;
 
-    std::cout << "========== Parameters ==========" << std::endl;
-    std::cout << std::boolalpha;
-    std::cout << "Key type: " << key_type << std::endl;
-    std::cout << "Payload type: " << payload_type << std::endl;
-    std::cout << "Number of rows in the build table: "
-              << static_cast<uint64_t>(BUILD_TABLE_NROWS_EACH_RANK) * mpi_size / 1e6
-              << " million" << std::endl;
-    std::cout << "Number of rows in the probe table: "
-              << static_cast<uint64_t>(PROBE_TABLE_NROWS_EACH_RANK) * mpi_size / 1e6
-              << " million" << std::endl;
-    std::cout << "Selectivity: " << SELECTIVITY << std::endl;
-    std::cout << "Keys in build table are unique: " << IS_BUILD_TABLE_KEY_UNIQUE << std::endl;
-    std::cout << "Over-decomposition factor: " << OVER_DECOMPOSITION_FACTOR << std::endl;
-    std::cout << "Communicator: " << COMMUNICATOR_NAME << std::endl;
-    if (COMMUNICATOR_NAME == "UCX")
-        std::cout << "Buffer communicator: " << USE_BUFFER_COMMUNICATOR << std::endl;
-    std::cout << "================================" << std::endl;
+  std::cout << "========== Parameters ==========" << std::endl;
+  std::cout << std::boolalpha;
+  std::cout << "Key type: " << key_type << std::endl;
+  std::cout << "Payload type: " << payload_type << std::endl;
+  std::cout << "Number of rows in the build table: "
+            << static_cast<uint64_t>(BUILD_TABLE_NROWS_EACH_RANK) * mpi_size / 1e6 << " million"
+            << std::endl;
+  std::cout << "Number of rows in the probe table: "
+            << static_cast<uint64_t>(PROBE_TABLE_NROWS_EACH_RANK) * mpi_size / 1e6 << " million"
+            << std::endl;
+  std::cout << "Selectivity: " << SELECTIVITY << std::endl;
+  std::cout << "Keys in build table are unique: " << IS_BUILD_TABLE_KEY_UNIQUE << std::endl;
+  std::cout << "Over-decomposition factor: " << OVER_DECOMPOSITION_FACTOR << std::endl;
+  std::cout << "Communicator: " << COMMUNICATOR_NAME << std::endl;
+  if (COMMUNICATOR_NAME == "UCX")
+    std::cout << "Buffer communicator: " << USE_BUFFER_COMMUNICATOR << std::endl;
+  std::cout << "================================" << std::endl;
 }
-
 
 int main(int argc, char *argv[])
 {
-    /* Initialize topology */
+  /* Initialize topology */
 
-    setup_topology(argc, argv);
+  setup_topology(argc, argv);
 
-    /* Parse command line arguments */
+  /* Parse command line arguments */
 
-    parse_command_line_arguments(argc, argv);
-    report_configuration();
+  parse_command_line_arguments(argc, argv);
+  report_configuration();
 
-    cudf::size_type RAND_MAX_VAL = std::max(BUILD_TABLE_NROWS_EACH_RANK, PROBE_TABLE_NROWS_EACH_RANK) * 2;
+  cudf::size_type RAND_MAX_VAL =
+    std::max(BUILD_TABLE_NROWS_EACH_RANK, PROBE_TABLE_NROWS_EACH_RANK) * 2;
 
-    /* Initialize communicator and memory pool */
+  /* Initialize communicator and memory pool */
 
-    int mpi_rank;
-    int mpi_size;
-    MPI_CALL( MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank) );
-    MPI_CALL( MPI_Comm_size(MPI_COMM_WORLD, &mpi_size) );
+  int mpi_rank;
+  int mpi_size;
+  MPI_CALL(MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank));
+  MPI_CALL(MPI_Comm_size(MPI_COMM_WORLD, &mpi_size));
 
-    Communicator *communicator { nullptr };
-    // `mr` holds reference to the registered memory resource, and *nullptr* if registered memory
-    // resource is not used.
-    registered_memory_resource *mr { nullptr };
-    // pool_mr need to live on heap because for registered memory resources, the memory pool needs
-    // to deallocated before UCX cleanup, which can be achieved by calling the destructor of
-    // `poll_mr`.
-    rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> *pool_mr { nullptr };
+  Communicator *communicator{nullptr};
+  // `mr` holds reference to the registered memory resource, and *nullptr* if registered memory
+  // resource is not used.
+  registered_memory_resource *mr{nullptr};
+  // pool_mr need to live on heap because for registered memory resources, the memory pool needs
+  // to deallocated before UCX cleanup, which can be achieved by calling the destructor of
+  // `poll_mr`.
+  rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> *pool_mr{nullptr};
 
-    // Calculate the memory pool size
-    size_t free_memory, total_memory;
-    CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
-    const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
+  // Calculate the memory pool size
+  size_t free_memory, total_memory;
+  CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
+  const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
 
-    if (COMMUNICATOR_NAME == "UCX" && USE_BUFFER_COMMUNICATOR) {
-        // For UCX with buffer communicator, a memory pool is first constructed so that the
-        // communication buffers will be allocated in memory pool.
-        pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
-            rmm::mr::get_current_device_resource(), pool_size, pool_size);
-        rmm::mr::set_current_device_resource(pool_mr);
-        // *2 because buffers are needed for both sends and receives
-        const int num_comm_buffers = 2 * mpi_size;
-        communicator = initialize_ucx_communicator(
-            true, num_comm_buffers, COMMUNICATOR_BUFFER_SIZE / num_comm_buffers - 100'000LL
-        );
-    } else if (COMMUNICATOR_NAME == "UCX" && !USE_BUFFER_COMMUNICATOR) {
-        // For UCX with preregistered memory pool, a communicator is first constructed so that
-        // `registered_memory_resource` can use the communicator for buffer registrations.
-        UCXCommunicator *ucx_communicator = initialize_ucx_communicator(false, 0, 0);
-        communicator = ucx_communicator;
-        mr = new registered_memory_resource(ucx_communicator);
-        pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
-            mr, pool_size, pool_size);
-        rmm::mr::set_current_device_resource(pool_mr);
-    } else if (COMMUNICATOR_NAME == "NCCL") {
-        communicator = new NCCLCommunicator;
-        communicator->initialize();
-        pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
-            rmm::mr::get_current_device_resource(), pool_size, pool_size);
-        rmm::mr::set_current_device_resource(pool_mr);
-    } else {
-        throw std::runtime_error("Unknown communicator name");
-    }
+  if (COMMUNICATOR_NAME == "UCX" && USE_BUFFER_COMMUNICATOR) {
+    // For UCX with buffer communicator, a memory pool is first constructed so that the
+    // communication buffers will be allocated in memory pool.
+    pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
+      rmm::mr::get_current_device_resource(), pool_size, pool_size);
+    rmm::mr::set_current_device_resource(pool_mr);
+    // *2 because buffers are needed for both sends and receives
+    const int num_comm_buffers = 2 * mpi_size;
+    communicator               = initialize_ucx_communicator(
+      true, num_comm_buffers, COMMUNICATOR_BUFFER_SIZE / num_comm_buffers - 100'000LL);
+  } else if (COMMUNICATOR_NAME == "UCX" && !USE_BUFFER_COMMUNICATOR) {
+    // For UCX with preregistered memory pool, a communicator is first constructed so that
+    // `registered_memory_resource` can use the communicator for buffer registrations.
+    UCXCommunicator *ucx_communicator = initialize_ucx_communicator(false, 0, 0);
+    communicator                      = ucx_communicator;
+    mr                                = new registered_memory_resource(ucx_communicator);
+    pool_mr =
+      new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(mr, pool_size, pool_size);
+    rmm::mr::set_current_device_resource(pool_mr);
+  } else if (COMMUNICATOR_NAME == "NCCL") {
+    communicator = new NCCLCommunicator;
+    communicator->initialize();
+    pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
+      rmm::mr::get_current_device_resource(), pool_size, pool_size);
+    rmm::mr::set_current_device_resource(pool_mr);
+  } else {
+    throw std::runtime_error("Unknown communicator name");
+  }
 
-    /* Generate build table and probe table on each rank */
+  /* Generate build table and probe table on each rank */
 
-    std::unique_ptr<cudf::table> left;
-    std::unique_ptr<cudf::table> right;
+  std::unique_ptr<cudf::table> left;
+  std::unique_ptr<cudf::table> right;
 
-    #define generate_tables(KEY_T, PAYLOAD_T)                                  \
-    {                                                                          \
-        std::tie(left, right) = generate_tables_distributed<KEY_T, PAYLOAD_T>( \
-            BUILD_TABLE_NROWS_EACH_RANK, PROBE_TABLE_NROWS_EACH_RANK,          \
-            SELECTIVITY, RAND_MAX_VAL, IS_BUILD_TABLE_KEY_UNIQUE,              \
-            communicator                                                       \
-        );                                                                     \
-    }
+#define generate_tables(KEY_T, PAYLOAD_T)                                        \
+  {                                                                              \
+    std::tie(left, right) =                                                      \
+      generate_tables_distributed<KEY_T, PAYLOAD_T>(BUILD_TABLE_NROWS_EACH_RANK, \
+                                                    PROBE_TABLE_NROWS_EACH_RANK, \
+                                                    SELECTIVITY,                 \
+                                                    RAND_MAX_VAL,                \
+                                                    IS_BUILD_TABLE_KEY_UNIQUE,   \
+                                                    communicator);               \
+  }
 
-    #define generate_tables_key_type(KEY_T)                                    \
-    {                                                                          \
-        if (payload_type == "int64_t") {                                       \
-            generate_tables(KEY_T, int64_t)                                    \
-        } else if (payload_type == "int32_t") {                                \
-            generate_tables(KEY_T, int32_t)                                    \
-        } else {                                                               \
-            throw std::runtime_error("Unknown payload type");                  \
-        }                                                                      \
-    }
+#define generate_tables_key_type(KEY_T)                 \
+  {                                                     \
+    if (payload_type == "int64_t") {                    \
+      generate_tables(KEY_T, int64_t)                   \
+    } else if (payload_type == "int32_t") {             \
+      generate_tables(KEY_T, int32_t)                   \
+    } else {                                            \
+      throw std::runtime_error("Unknown payload type"); \
+    }                                                   \
+  }
 
-    if (key_type == "int64_t") {
-        generate_tables_key_type(int64_t)
-    } else if (key_type == "int32_t") {
-        generate_tables_key_type(int32_t)
-    } else {
-        throw std::runtime_error("Unknown key type");
-    }
+  if (key_type == "int64_t") {
+    generate_tables_key_type(int64_t)
+  } else if (key_type == "int32_t") {
+    generate_tables_key_type(int32_t)
+  } else {
+    throw std::runtime_error("Unknown key type");
+  }
 
-    /* Distributed join */
+  /* Distributed join */
 
-    CUDA_RT_CALL(cudaDeviceSynchronize());
+  CUDA_RT_CALL(cudaDeviceSynchronize());
 
-    MPI_Barrier(MPI_COMM_WORLD);
-    cudaProfilerStart();
-    double start = MPI_Wtime();
+  MPI_Barrier(MPI_COMM_WORLD);
+  cudaProfilerStart();
+  double start = MPI_Wtime();
 
-    std::unique_ptr<cudf::table> join_result = distributed_inner_join(
-        left->view(), right->view(),
-        {0}, {0}, {std::pair<cudf::size_type, cudf::size_type>(0, 0)},
-        communicator, OVER_DECOMPOSITION_FACTOR
-    );
+  std::unique_ptr<cudf::table> join_result =
+    distributed_inner_join(left->view(),
+                           right->view(),
+                           {0},
+                           {0},
+                           {std::pair<cudf::size_type, cudf::size_type>(0, 0)},
+                           communicator,
+                           OVER_DECOMPOSITION_FACTOR);
 
-    MPI_Barrier(MPI_COMM_WORLD);
-    double stop = MPI_Wtime();
-    cudaProfilerStop();
+  MPI_Barrier(MPI_COMM_WORLD);
+  double stop = MPI_Wtime();
+  cudaProfilerStop();
 
-    if (mpi_rank == 0) {
-        std::cout << "Elasped time (s) " << stop - start << std::endl;
-    }
+  if (mpi_rank == 0) { std::cout << "Elasped time (s) " << stop - start << std::endl; }
 
-    /* Cleanup */
-    left.reset();
-    right.reset();
-    join_result.reset();
-    CUDA_RT_CALL( cudaDeviceSynchronize() );
+  /* Cleanup */
+  left.reset();
+  right.reset();
+  join_result.reset();
+  CUDA_RT_CALL(cudaDeviceSynchronize());
 
-    if (USE_BUFFER_COMMUNICATOR) {
-        // When finalizing buffer communicator, communication buffers need be deallocated, so
-        // `finalize` needs to be called before the memory pool is deleted.
-        communicator->finalize();
-        delete pool_mr;
-        delete mr;
-    } else {
-        // For registered memory resouce, the memory pool needs to be deleted before finalizing
-        // the communicator, so that all buffers can be deregistered through UCX.
-        delete pool_mr;
-        delete mr;
-        communicator->finalize();
-    }
+  if (USE_BUFFER_COMMUNICATOR) {
+    // When finalizing buffer communicator, communication buffers need be deallocated, so
+    // `finalize` needs to be called before the memory pool is deleted.
+    communicator->finalize();
+    delete pool_mr;
+    delete mr;
+  } else {
+    // For registered memory resouce, the memory pool needs to be deleted before finalizing
+    // the communicator, so that all buffers can be deregistered through UCX.
+    delete pool_mr;
+    delete mr;
+    communicator->finalize();
+  }
 
-    delete communicator;
+  delete communicator;
 
-    MPI_CALL( MPI_Finalize() );
+  MPI_CALL(MPI_Finalize());
 
-    return 0;
+  return 0;
 }

--- a/generate_dataset/generate_dataset.cuh
+++ b/generate_dataset/generate_dataset.cuh
@@ -19,126 +19,118 @@
 
 #include <curand.h>
 #include <curand_kernel.h>
-#include <thrust/sequence.h>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/distance.h>
-#include <cassert>
 #include <rmm/thrust_rmm_allocator.h>
+#include <thrust/distance.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/sequence.h>
+#include <cassert>
 
 #include "../src/error.cuh"
 #include "nvtx_helper.cuh"
 
-
 /* redefine atomic compare and swap with signed type */
-__device__ __inline__
-int64_t atomicCAS(int64_t* address, int64_t compare, int64_t val)
+__device__ __inline__ int64_t atomicCAS(int64_t* address, int64_t compare, int64_t val)
 {
-    return (int64_t)atomicCAS((unsigned long long int*)address, (unsigned long long int)compare, (unsigned long long int)val);
+  return (int64_t)atomicCAS(
+    (unsigned long long int*)address, (unsigned long long int)compare, (unsigned long long int)val);
 }
 
-
-__global__ static void init_curand(curandState * state, const int nstates)
+__global__ static void init_curand(curandState* state, const int nstates)
 {
-    int ithread = threadIdx.x + blockIdx.x * blockDim.x;
+  int ithread = threadIdx.x + blockIdx.x * blockDim.x;
 
-    if (ithread < nstates) {
-        curand_init(1234ULL, ithread, 0, state + ithread);
+  if (ithread < nstates) { curand_init(1234ULL, ithread, 0, state + ithread); }
+}
+
+template <typename key_type, typename size_type>
+__global__ static void init_build_tbl(key_type* const build_tbl,
+                                      const size_type build_tbl_size,
+                                      const key_type rand_max,
+                                      const bool uniq_build_tbl_keys,
+                                      key_type* const lottery,
+                                      const size_type lottery_size,
+                                      curandState* state,
+                                      const int num_states)
+{
+  static_assert(std::is_signed<key_type>::value, "key_type needs to be signed for lottery to work");
+
+  const int start_idx   = blockIdx.x * blockDim.x + threadIdx.x;
+  const key_type stride = blockDim.x * gridDim.x;
+  assert(start_idx < num_states);
+
+  curandState localState = state[start_idx];
+
+  for (size_type idx = start_idx; idx < build_tbl_size; idx += stride) {
+    const double x = curand_uniform_double(&localState);
+
+    if (uniq_build_tbl_keys) {
+      // If the build table keys need to be unique, go through lottery array from lottery_idx until
+      // finding a key which has not been used (-1). Mark the key as been used by atomically setting
+      // the spot to -1.
+
+      size_type lottery_idx = x * lottery_size;
+      key_type lottery_val  = -1;
+
+      while (-1 == lottery_val) {
+        lottery_val = lottery[lottery_idx];
+
+        if (-1 != lottery_val) { lottery_val = atomicCAS(lottery + lottery_idx, lottery_val, -1); }
+
+        lottery_idx = (lottery_idx + 1) % lottery_size;
+      }
+
+      build_tbl[idx] = lottery_val;
+    } else {
+      build_tbl[idx] = x * rand_max;
     }
+  }
+
+  state[start_idx] = localState;
 }
 
-
-template<typename key_type, typename size_type>
-__global__ static void init_build_tbl(
-    key_type* const build_tbl, const size_type build_tbl_size,
-    const key_type rand_max,
-    const bool uniq_build_tbl_keys,
-    key_type* const lottery, const size_type lottery_size,
-    curandState * state, const int num_states)
-{
-    static_assert(std::is_signed<key_type>::value, "key_type needs to be signed for lottery to work");
-
-    const int start_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    const key_type stride = blockDim.x * gridDim.x;
-    assert(start_idx < num_states);
-
-    curandState localState = state[start_idx];
-
-    for (size_type idx = start_idx; idx < build_tbl_size; idx += stride) {
-        const double x = curand_uniform_double(&localState);
-
-        if (uniq_build_tbl_keys) {
-            // If the build table keys need to be unique, go through lottery array from lottery_idx until finding a key
-            // which has not been used (-1). Mark the key as been used by atomically setting the spot to -1.
-
-            size_type lottery_idx = x * lottery_size;
-            key_type lottery_val = -1;
-
-            while (-1 == lottery_val) {
-                lottery_val = lottery[lottery_idx];
-
-                if (-1 != lottery_val) {
-                    lottery_val = atomicCAS(lottery + lottery_idx, lottery_val, -1);
-                }
-
-                lottery_idx = (lottery_idx + 1) % lottery_size;
-            }
-
-            build_tbl[idx] = lottery_val;
-        } else {
-            build_tbl[idx] = x * rand_max;
-        }
-    }
-
-    state[start_idx] = localState;
-}
-
-
-template<typename key_type, typename size_type>
-__global__ void init_probe_tbl(
-                               key_type* const probe_tbl,
+template <typename key_type, typename size_type>
+__global__ void init_probe_tbl(key_type* const probe_tbl,
                                const size_type probe_tbl_size,
                                const key_type* const build_tbl,
                                const size_type build_tbl_size,
                                const key_type* const lottery,
                                const size_type lottery_size,
                                const double selectivity,
-                               curandState * state,
+                               curandState* state,
                                const int num_states)
 {
-    const int start_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    const size_type stride = blockDim.x * gridDim.x;
-    assert(start_idx < num_states);
+  const int start_idx    = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_type stride = blockDim.x * gridDim.x;
+  assert(start_idx < num_states);
 
-    curandState localState = state[start_idx];
+  curandState localState = state[start_idx];
 
-    for (size_type idx = start_idx; idx < probe_tbl_size; idx += stride) {
-        key_type val;
-        double x = curand_uniform_double(&localState);
+  for (size_type idx = start_idx; idx < probe_tbl_size; idx += stride) {
+    key_type val;
+    double x = curand_uniform_double(&localState);
 
-        if (x <= selectivity) {
-            // x <= selectivity means this key in the probe table should be present in the build table, so we pick a
-            // key from build_tbl
-            x = curand_uniform_double(&localState);
-            size_type build_tbl_idx = x * build_tbl_size;
+    if (x <= selectivity) {
+      // x <= selectivity means this key in the probe table should be present in the build table, so
+      // we pick a key from build_tbl
+      x                       = curand_uniform_double(&localState);
+      size_type build_tbl_idx = x * build_tbl_size;
 
-            if (build_tbl_idx >= build_tbl_size) {
-                build_tbl_idx = build_tbl_size - 1;
-            }
+      if (build_tbl_idx >= build_tbl_size) { build_tbl_idx = build_tbl_size - 1; }
 
-            val = build_tbl[build_tbl_idx];
-        } else {
-            // This key in the probe table should not be present in the build table, so we pick a key from lottery.
-            x = curand_uniform_double(&localState);
-            size_type lottery_idx = x * lottery_size;
-            val = lottery[lottery_idx];
-        }
-
-        probe_tbl[idx] = val;
+      val = build_tbl[build_tbl_idx];
+    } else {
+      // This key in the probe table should not be present in the build table, so we pick a key from
+      // lottery.
+      x                     = curand_uniform_double(&localState);
+      size_type lottery_idx = x * lottery_size;
+      val                   = lottery[lottery_idx];
     }
 
-    state[start_idx] = localState;
-}
+    probe_tbl[idx] = val;
+  }
 
+  state[start_idx] = localState;
+}
 
 /**
  * generate_input_tables generates random integer input tables for database benchmarks.
@@ -166,9 +158,8 @@ __global__ void init_probe_tbl(
  *                                  integers from [0,rand_max].
  * @param[in] uniq_build_tbl_keys   if each key in the build table should appear exactly once.
  */
-template<typename key_type, typename size_type>
-void generate_input_tables(
-                           key_type* const build_tbl,
+template <typename key_type, typename size_type>
+void generate_input_tables(key_type* const build_tbl,
                            const size_type build_tbl_size,
                            key_type* const probe_tbl,
                            const size_type probe_tbl_size,
@@ -176,85 +167,94 @@ void generate_input_tables(
                            const key_type rand_max,
                            const bool uniq_build_tbl_keys)
 {
-    // With large values of rand_max the a lot of temporary storage is needed for the lottery. At the expense of not
-    // being that accurate with applying the selectivity an especially more memory efficient implementations would be
-    // to partition the random numbers into two intervals and then let one table choose random numbers from only one
-    // interval and the other only select with selectivity propability from the same interval and from the other in the
-    // other cases.
+  // With large values of rand_max the a lot of temporary storage is needed for the lottery. At the
+  // expense of not being that accurate with applying the selectivity an especially more memory
+  // efficient implementations would be to partition the random numbers into two intervals and then
+  // let one table choose random numbers from only one interval and the other only select with
+  // selectivity propability from the same interval and from the other in the other cases.
 
-    static_assert(std::is_signed<key_type>::value, "key_type needs to be signed for lottery to work");
+  static_assert(std::is_signed<key_type>::value, "key_type needs to be signed for lottery to work");
 
-    const int block_size = 128;
+  const int block_size = 128;
 
-    // Maximize exposed parallelism while minimizing storage for curand state
-    int num_blocks_init_build_tbl {-1};
-    CUDA_RT_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &num_blocks_init_build_tbl, init_build_tbl<key_type, size_type>, block_size, 0
-    ));
+  // Maximize exposed parallelism while minimizing storage for curand state
+  int num_blocks_init_build_tbl{-1};
+  CUDA_RT_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+    &num_blocks_init_build_tbl, init_build_tbl<key_type, size_type>, block_size, 0));
 
-    int num_blocks_init_probe_tbl {-1};
-    CUDA_RT_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &num_blocks_init_probe_tbl, init_probe_tbl<key_type,size_type>, block_size, 0
-    ));
+  int num_blocks_init_probe_tbl{-1};
+  CUDA_RT_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+    &num_blocks_init_probe_tbl, init_probe_tbl<key_type, size_type>, block_size, 0));
 
-    int dev_id {-1};
-    CUDA_RT_CALL(cudaGetDevice(&dev_id));
+  int dev_id{-1};
+  CUDA_RT_CALL(cudaGetDevice(&dev_id));
 
-    int num_sms {-1};
-    CUDA_RT_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
+  int num_sms{-1};
+  CUDA_RT_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
 
-    const int num_states =
-        num_sms * std::max(num_blocks_init_build_tbl, num_blocks_init_probe_tbl) * block_size;
-    rmm::device_vector<curandState> devStates(num_states);
+  const int num_states =
+    num_sms * std::max(num_blocks_init_build_tbl, num_blocks_init_probe_tbl) * block_size;
+  rmm::device_vector<curandState> devStates(num_states);
 
-    init_curand<<<(num_states - 1) / block_size + 1, block_size>>>(devStates.data().get(),
-                                                                   num_states);
+  init_curand<<<(num_states - 1) / block_size + 1, block_size>>>(devStates.data().get(),
+                                                                 num_states);
 
-    CUDA_RT_CALL(cudaGetLastError());
-    CUDA_RT_CALL(cudaDeviceSynchronize());
+  CUDA_RT_CALL(cudaGetLastError());
+  CUDA_RT_CALL(cudaDeviceSynchronize());
 
-    rmm::device_vector<key_type> build_tbl_sorted(build_tbl_size);
+  rmm::device_vector<key_type> build_tbl_sorted(build_tbl_size);
 
-    size_type lottery_size = rand_max < std::numeric_limits<key_type>::max() - 1 ? rand_max + 1 : rand_max;
-    rmm::device_vector<key_type> lottery(lottery_size);
+  size_type lottery_size =
+    rand_max < std::numeric_limits<key_type>::max() - 1 ? rand_max + 1 : rand_max;
+  rmm::device_vector<key_type> lottery(lottery_size);
 
-    if (uniq_build_tbl_keys) {
-        thrust::sequence(thrust::device, lottery.begin(), lottery.end(), 0);
-    }
+  if (uniq_build_tbl_keys) { thrust::sequence(thrust::device, lottery.begin(), lottery.end(), 0); }
 
-    init_build_tbl<key_type, size_type><<<num_sms * num_blocks_init_build_tbl, block_size>>>(
-        build_tbl, build_tbl_size, rand_max, uniq_build_tbl_keys,
-        lottery.data().get(), lottery_size, devStates.data().get(), num_states
-    );
+  init_build_tbl<key_type, size_type>
+    <<<num_sms * num_blocks_init_build_tbl, block_size>>>(build_tbl,
+                                                          build_tbl_size,
+                                                          rand_max,
+                                                          uniq_build_tbl_keys,
+                                                          lottery.data().get(),
+                                                          lottery_size,
+                                                          devStates.data().get(),
+                                                          num_states);
 
-    CUDA_RT_CALL(cudaGetLastError());
-    CUDA_RT_CALL(cudaDeviceSynchronize());
+  CUDA_RT_CALL(cudaGetLastError());
+  CUDA_RT_CALL(cudaDeviceSynchronize());
 
-    CUDA_RT_CALL(cudaMemcpy(
-        build_tbl_sorted.data().get(), build_tbl, build_tbl_size * sizeof(key_type),
-        cudaMemcpyDeviceToDevice
-    ));
+  CUDA_RT_CALL(cudaMemcpy(build_tbl_sorted.data().get(),
+                          build_tbl,
+                          build_tbl_size * sizeof(key_type),
+                          cudaMemcpyDeviceToDevice));
 
-    thrust::sort(thrust::device, build_tbl_sorted.begin(), build_tbl_sorted.end());
+  thrust::sort(thrust::device, build_tbl_sorted.begin(), build_tbl_sorted.end());
 
-    // Exclude keys used in build table from lottery
-    thrust::counting_iterator<key_type> first_lottery_elem(0);
-    thrust::counting_iterator<key_type> last_lottery_elem = first_lottery_elem + lottery_size;
-    key_type *lottery_end = thrust::set_difference(
-        thrust::device, first_lottery_elem, last_lottery_elem,
-        build_tbl_sorted.begin(), build_tbl_sorted.end(), lottery.data().get()
-    );
+  // Exclude keys used in build table from lottery
+  thrust::counting_iterator<key_type> first_lottery_elem(0);
+  thrust::counting_iterator<key_type> last_lottery_elem = first_lottery_elem + lottery_size;
+  key_type* lottery_end                                 = thrust::set_difference(thrust::device,
+                                                 first_lottery_elem,
+                                                 last_lottery_elem,
+                                                 build_tbl_sorted.begin(),
+                                                 build_tbl_sorted.end(),
+                                                 lottery.data().get());
 
-    lottery_size = thrust::distance(lottery.data().get(), lottery_end);
+  lottery_size = thrust::distance(lottery.data().get(), lottery_end);
 
-    init_probe_tbl<key_type, size_type><<<num_sms * num_blocks_init_build_tbl, block_size>>>(
-        probe_tbl, probe_tbl_size, build_tbl, build_tbl_size,
-        lottery.data().get(), lottery_size, selectivity, devStates.data().get(), num_states
-    );
+  init_probe_tbl<key_type, size_type>
+    <<<num_sms * num_blocks_init_build_tbl, block_size>>>(probe_tbl,
+                                                          probe_tbl_size,
+                                                          build_tbl,
+                                                          build_tbl_size,
+                                                          lottery.data().get(),
+                                                          lottery_size,
+                                                          selectivity,
+                                                          devStates.data().get(),
+                                                          num_states);
 
-    CUDA_RT_CALL(cudaGetLastError());
-    CUDA_RT_CALL(cudaDeviceSynchronize());
+  CUDA_RT_CALL(cudaGetLastError());
+  CUDA_RT_CALL(cudaDeviceSynchronize());
 }
 
-
-#endif //GENERATE_INPUT_TABLES_CUH
+#endif  // GENERATE_INPUT_TABLES_CUH

--- a/generate_dataset/nvtx_helper.cuh
+++ b/generate_dataset/nvtx_helper.cuh
@@ -20,25 +20,27 @@
 #ifdef USE_NVTX
 #include <nvToolsExt.h>
 
-static const uint32_t colors[] = { 0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff, 0x0000ffff, 0x00ff0000, 0x00ffffff };
-static const int num_colors = sizeof(colors)/sizeof(uint32_t);
+static const uint32_t colors[] = {
+  0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff, 0x0000ffff, 0x00ff0000, 0x00ffffff};
+static const int num_colors = sizeof(colors) / sizeof(uint32_t);
 
-#define PUSH_RANGE(name,cid) { \
-    int color_id = cid; \
-    color_id = color_id%num_colors;\
-    nvtxEventAttributes_t eventAttrib = {0}; \
-    eventAttrib.version = NVTX_VERSION; \
-    eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE; \
-    eventAttrib.colorType = NVTX_COLOR_ARGB; \
-    eventAttrib.color = colors[color_id]; \
-    eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII; \
-    eventAttrib.message.ascii = name; \
-    nvtxRangePushEx(&eventAttrib); \
-}
+#define PUSH_RANGE(name, cid)                                          \
+  {                                                                    \
+    int color_id                      = cid;                           \
+    color_id                          = color_id % num_colors;         \
+    nvtxEventAttributes_t eventAttrib = {0};                           \
+    eventAttrib.version               = NVTX_VERSION;                  \
+    eventAttrib.size                  = NVTX_EVENT_ATTRIB_STRUCT_SIZE; \
+    eventAttrib.colorType             = NVTX_COLOR_ARGB;               \
+    eventAttrib.color                 = colors[color_id];              \
+    eventAttrib.messageType           = NVTX_MESSAGE_TYPE_ASCII;       \
+    eventAttrib.message.ascii         = name;                          \
+    nvtxRangePushEx(&eventAttrib);                                     \
+  }
 #define POP_RANGE nvtxRangePop();
 #else
-#define PUSH_RANGE(name,cid)
+#define PUSH_RANGE(name, cid)
 #define POP_RANGE
 #endif
 
-#endif //NVTX_HELPER_CUH
+#endif  // NVTX_HELPER_CUH

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+import glob
+import argparse
+import subprocess
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", "--path", default="clang-format", help="Path to clang-format executable")
+args = parser.parse_args()
+
+extensions = ["cu", "cpp", "h", "cuh", "hpp"]
+file_paths = []
+
+for extension in extensions:
+    file_paths.extend(glob.glob('**/*.{}'.format(extension), recursive=True))
+
+for file_path in file_paths:
+    subprocess.run([args.path, "-i", "-style=file", file_path])

--- a/src/comm.cuh
+++ b/src/comm.cuh
@@ -17,44 +17,48 @@
 #ifndef __COMM_CUH
 #define __COMM_CUH
 
-#include <vector>
 #include <mpi.h>
 #include <cudf/types.hpp>
+#include <vector>
 
 #include "communicator.h"
 #include "error.cuh"
 
-
-enum COMM_TAGS
-{
-    placeholder_tag,
-    exchange_size_tag
-};
-
+enum COMM_TAGS { placeholder_tag, exchange_size_tag };
 
 /**
- * Usage: mpi_dtype_from_c_type<input_type>() returns the MPI datatype corresponding to a native C type "input_type".
+ * Usage: mpi_dtype_from_c_type<input_type>() returns the MPI datatype corresponding to a native C
+ * type "input_type".
  *
  * For example, mpi_dtype_from_c_type<int>() would return MPI_INT32_T.
  */
 template <typename c_type>
 MPI_Datatype mpi_dtype_from_c_type()
 {
-    MPI_Datatype mpi_dtype;
-    if(std::is_same<c_type,int8_t>::value) mpi_dtype = MPI_INT8_T;
-    else if(std::is_same<c_type,uint8_t>::value) mpi_dtype = MPI_UINT8_T;
-    else if(std::is_same<c_type,int16_t>::value) mpi_dtype = MPI_INT16_T;
-    else if(std::is_same<c_type,uint16_t>::value) mpi_dtype = MPI_UINT16_T;
-    else if(std::is_same<c_type,int32_t>::value) mpi_dtype = MPI_INT32_T;
-    else if(std::is_same<c_type,uint32_t>::value) mpi_dtype = MPI_UINT32_T;
-    else if(std::is_same<c_type,int64_t>::value) mpi_dtype = MPI_INT64_T;
-    else if(std::is_same<c_type,uint64_t>::value) mpi_dtype = MPI_UINT64_T;
-    else if(std::is_same<c_type,float>::value) mpi_dtype = MPI_FLOAT;
-    else if(std::is_same<c_type,double>::value) mpi_dtype = MPI_DOUBLE;
+  MPI_Datatype mpi_dtype;
+  if (std::is_same<c_type, int8_t>::value)
+    mpi_dtype = MPI_INT8_T;
+  else if (std::is_same<c_type, uint8_t>::value)
+    mpi_dtype = MPI_UINT8_T;
+  else if (std::is_same<c_type, int16_t>::value)
+    mpi_dtype = MPI_INT16_T;
+  else if (std::is_same<c_type, uint16_t>::value)
+    mpi_dtype = MPI_UINT16_T;
+  else if (std::is_same<c_type, int32_t>::value)
+    mpi_dtype = MPI_INT32_T;
+  else if (std::is_same<c_type, uint32_t>::value)
+    mpi_dtype = MPI_UINT32_T;
+  else if (std::is_same<c_type, int64_t>::value)
+    mpi_dtype = MPI_INT64_T;
+  else if (std::is_same<c_type, uint64_t>::value)
+    mpi_dtype = MPI_UINT64_T;
+  else if (std::is_same<c_type, float>::value)
+    mpi_dtype = MPI_FLOAT;
+  else if (std::is_same<c_type, double>::value)
+    mpi_dtype = MPI_DOUBLE;
 
-    return mpi_dtype;
+  return mpi_dtype;
 }
-
 
 /**
  * Send data from the current rank to other ranks according to offset.
@@ -62,39 +66,35 @@ MPI_Datatype mpi_dtype_from_c_type()
  * Note: This call should be enclosed by communicator->start() and communicator->stop().
  *
  * @param[in] data                The starting address of data to be sent in device buffer.
- * @param[in] offset              Vector of length mpi_size + 1. Items in *data* with indicies from offset[i] to
- *                                offset[i+1] will be sent to rank i.
+ * @param[in] offset              Vector of length mpi_size + 1. Items in *data* with indicies from
+ * offset[i] to offset[i+1] will be sent to rank i.
  * @param[in] item_size           The size of each item.
  * @param[in] communicator        An instance of 'Communicator' used for communication.
- * @param[in] self_send           Whether sending data to itself. If this argument is false, items in *data* destined for the
- *                                current rank will not be copied.
+ * @param[in] self_send           Whether sending data to itself. If this argument is false, items
+ * in *data* destined for the current rank will not be copied.
  */
-void
-send_data_by_offset(
-    const void *data,
-    std::vector<int> const& offset,
-    size_t item_size,
-    Communicator *communicator,
-    bool self_send=true)
+void send_data_by_offset(const void *data,
+                         std::vector<int> const &offset,
+                         size_t item_size,
+                         Communicator *communicator,
+                         bool self_send = true)
 {
-    int mpi_rank {communicator->mpi_rank};
-    int mpi_size {communicator->mpi_size};
+  int mpi_rank{communicator->mpi_rank};
+  int mpi_size{communicator->mpi_size};
 
-    for (int itarget_rank = 0; itarget_rank < mpi_size; itarget_rank++) {
-        if (!self_send && itarget_rank == mpi_rank)
-            continue;
+  for (int itarget_rank = 0; itarget_rank < mpi_size; itarget_rank++) {
+    if (!self_send && itarget_rank == mpi_rank) continue;
 
-        // calculate the number of elements to send
-        size_t count = offset[itarget_rank + 1] - offset[itarget_rank];
+    // calculate the number of elements to send
+    size_t count = offset[itarget_rank + 1] - offset[itarget_rank];
 
-        // calculate the starting address
-        const void *start_addr = (void *)((char *)data + offset[itarget_rank] * item_size);
+    // calculate the starting address
+    const void *start_addr = (void *)((char *)data + offset[itarget_rank] * item_size);
 
-        // send buffer to the target rank
-        communicator->send(start_addr, count, item_size, itarget_rank);
-    }
+    // send buffer to the target rank
+    communicator->send(start_addr, count, item_size, itarget_rank);
+  }
 }
-
 
 /**
  * Receive data sent by 'send_data_by_offset'.
@@ -103,32 +103,30 @@ send_data_by_offset(
  *
  * @param[out] data         Items received from all ranks will be placed contiguously in *data*.
  *     This argument needs to be preallocated.
- * @param[in] offset        The items received from rank i will be stored at the start of `data[offset[i]]`.
+ * @param[in] offset        The items received from rank i will be stored at the start of
+ * `data[offset[i]]`.
  * @param[in] item_size     The size of each item.
  * @param[in] communicator  An instance of 'Communicator' used for communication.
  * @param[in] self_recv     Whether recving data from itself. If this argument is false, items in
  *                          *data* from the current rank will not be received.
  */
-void
-recv_data_by_offset(
-    void *data,
-    std::vector<int64_t> const& offset,
-    size_t item_size,
-    Communicator *communicator,
-    bool self_recv=true)
+void recv_data_by_offset(void *data,
+                         std::vector<int64_t> const &offset,
+                         size_t item_size,
+                         Communicator *communicator,
+                         bool self_recv = true)
 {
-    int mpi_rank {communicator->mpi_rank};
-    int mpi_size {communicator->mpi_size};
+  int mpi_rank{communicator->mpi_rank};
+  int mpi_size{communicator->mpi_size};
 
-    for (int isource_rank = 0; isource_rank < mpi_size; isource_rank++) {
-        if (!self_recv && mpi_rank == isource_rank)
-            continue;
+  for (int isource_rank = 0; isource_rank < mpi_size; isource_rank++) {
+    if (!self_recv && mpi_rank == isource_rank) continue;
 
-        communicator->recv(
-            (void *)((char *)data + offset[isource_rank] * item_size),
-            offset[isource_rank + 1] - offset[isource_rank], item_size, isource_rank
-        );
-    }
+    communicator->recv((void *)((char *)data + offset[isource_rank] * item_size),
+                       offset[isource_rank + 1] - offset[isource_rank],
+                       item_size,
+                       isource_rank);
+  }
 }
 
-#endif // __COMM_CUH
+#endif  // __COMM_CUH

--- a/src/communicator.cu
+++ b/src/communicator.cu
@@ -16,9 +16,9 @@
 
 #include <mpi.h>
 #include <ucp/api/ucp.h>
-#include <cstring>
-#include <cstdlib>
 #include <cassert>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 
@@ -27,381 +27,350 @@
 #include "communicator.h"
 #include "error.cuh"
 
-
 void Communicator::initialize()
 {
-    MPI_CALL( MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank) );
-    MPI_CALL( MPI_Comm_size(MPI_COMM_WORLD, &mpi_size) );
-    CUDA_RT_CALL( cudaGetDevice(&current_device) );
+  MPI_CALL(MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank));
+  MPI_CALL(MPI_Comm_size(MPI_COMM_WORLD, &mpi_size));
+  CUDA_RT_CALL(cudaGetDevice(&current_device));
 }
 
+void MPILikeCommunicator::initialize() { Communicator::initialize(); }
 
-void MPILikeCommunicator::initialize()
-{
-    Communicator::initialize();
-}
+void MPILikeCommunicator::start() { pending_requests.clear(); }
 
-
-void MPILikeCommunicator::start()
-{
-    pending_requests.clear();
-}
-
-
-void MPILikeCommunicator::stop()
-{
-    waitall(pending_requests);
-}
-
+void MPILikeCommunicator::stop() { waitall(pending_requests); }
 
 void MPILikeCommunicator::send(const void *buf, int64_t count, int element_size, int dest)
 {
-    pending_requests.push_back(
-        send(buf, count, element_size, dest, reserved_tag)
-    );
+  pending_requests.push_back(send(buf, count, element_size, dest, reserved_tag));
 }
-
 
 void MPILikeCommunicator::recv(void *buf, int64_t count, int element_size, int source)
 {
-    pending_requests.push_back(
-        recv(buf, count, element_size, source, reserved_tag)
-    );
+  pending_requests.push_back(recv(buf, count, element_size, source, reserved_tag));
 }
-
 
 void UCXCommunicator::initialize_ucx()
 {
-    ucp_params_t        ucp_params;
-    ucp_config_t        *ucp_config;
-    ucp_worker_params_t ucp_worker_params;
+  ucp_params_t ucp_params;
+  ucp_config_t *ucp_config;
+  ucp_worker_params_t ucp_worker_params;
 
-    memset(&ucp_params, 0, sizeof(ucp_params));
-    ucp_params.field_mask        = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_ESTIMATED_NUM_EPS;
-    ucp_params.features          = UCP_FEATURE_TAG;
-    ucp_params.estimated_num_eps = mpi_size;
+  memset(&ucp_params, 0, sizeof(ucp_params));
+  ucp_params.field_mask        = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_ESTIMATED_NUM_EPS;
+  ucp_params.features          = UCP_FEATURE_TAG;
+  ucp_params.estimated_num_eps = mpi_size;
 
-    UCX_CALL(ucp_config_read(NULL, NULL, &ucp_config));
+  UCX_CALL(ucp_config_read(NULL, NULL, &ucp_config));
 
-    UCX_CALL(ucp_init(&ucp_params, ucp_config, &ucp_context));
-    ucp_config_release(ucp_config);
+  UCX_CALL(ucp_init(&ucp_params, ucp_config, &ucp_context));
+  ucp_config_release(ucp_config);
 
-    memset(&ucp_worker_params, 0, sizeof(ucp_worker_params));
-    ucp_worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
-    ucp_worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;  // only the master thread can access UCX
+  memset(&ucp_worker_params, 0, sizeof(ucp_worker_params));
+  ucp_worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+  ucp_worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;  // only the master thread can access UCX
 
-    UCX_CALL(ucp_worker_create(ucp_context, &ucp_worker_params, &ucp_worker));
+  UCX_CALL(ucp_worker_create(ucp_context, &ucp_worker_params, &ucp_worker));
 
-    UCX_CALL(ucp_worker_get_address(ucp_worker, &ucp_worker_address, &ucp_worker_address_len));
+  UCX_CALL(ucp_worker_get_address(ucp_worker, &ucp_worker_address, &ucp_worker_address_len));
 }
-
 
 void UCXCommunicator::create_endpoints()
 {
-    /* Broadcast worker addresses to all ranks */
+  /* Broadcast worker addresses to all ranks */
 
-    void *ucp_worker_address_book = malloc(ucp_worker_address_len * mpi_size);
-    MPI_CALL(MPI_Allgather(
-        ucp_worker_address, ucp_worker_address_len, MPI_CHAR,
-        ucp_worker_address_book, ucp_worker_address_len, MPI_CHAR, MPI_COMM_WORLD
-    ));
+  void *ucp_worker_address_book = malloc(ucp_worker_address_len * mpi_size);
+  MPI_CALL(MPI_Allgather(ucp_worker_address,
+                         ucp_worker_address_len,
+                         MPI_CHAR,
+                         ucp_worker_address_book,
+                         ucp_worker_address_len,
+                         MPI_CHAR,
+                         MPI_COMM_WORLD));
 
-    /* Create endpoints on all ranks */
+  /* Create endpoints on all ranks */
 
-    std::vector<ucp_ep_params_t> ucp_ep_params;
+  std::vector<ucp_ep_params_t> ucp_ep_params;
 
-    ucp_endpoints.resize(mpi_size);
-    ucp_ep_params.resize(mpi_size);
+  ucp_endpoints.resize(mpi_size);
+  ucp_ep_params.resize(mpi_size);
 
-    for (int irank = 0; irank < mpi_size; irank++) {
-        memset(&ucp_ep_params[irank], 0, sizeof(ucp_ep_params));
-        ucp_ep_params[irank].field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-        ucp_ep_params[irank].address = (ucp_address_t *)(
-            (char *)ucp_worker_address_book + irank * ucp_worker_address_len
-        );
+  for (int irank = 0; irank < mpi_size; irank++) {
+    memset(&ucp_ep_params[irank], 0, sizeof(ucp_ep_params));
+    ucp_ep_params[irank].field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+    ucp_ep_params[irank].address =
+      (ucp_address_t *)((char *)ucp_worker_address_book + irank * ucp_worker_address_len);
 
-        UCX_CALL(ucp_ep_create(ucp_worker, &ucp_ep_params[irank], &ucp_endpoints[irank]));
-    }
+    UCX_CALL(ucp_ep_create(ucp_worker, &ucp_ep_params[irank], &ucp_endpoints[irank]));
+  }
 
-    free(ucp_worker_address_book);
+  free(ucp_worker_address_book);
 }
-
 
 void UCXCommunicator::initialize()
 {
-    MPILikeCommunicator::initialize();
-    initialize_ucx();
-    create_endpoints();
+  MPILikeCommunicator::initialize();
+  initialize_ucx();
+  create_endpoints();
 }
-
 
 void empty_callback_func() {}
 
-
-comm_handle_t UCXCommunicator::send(const void *buf, int64_t count, int element_size, int dest, int tag)
+comm_handle_t UCXCommunicator::send(
+  const void *buf, int64_t count, int element_size, int dest, int tag)
 {
-    // TODO: the design of the communication tag should be in line with the design of UCXBufferCommunicator
-    ucs_status_ptr_t req = ucp_tag_send_nb(
-        ucp_endpoints[dest], buf, count, ucp_dt_make_contig(element_size),
-        tag * mpi_size + mpi_rank, (ucp_send_callback_t) empty_callback_func
-    );
+  // TODO: the design of the communication tag should be in line with the design of
+  // UCXBufferCommunicator
+  ucs_status_ptr_t req = ucp_tag_send_nb(ucp_endpoints[dest],
+                                         buf,
+                                         count,
+                                         ucp_dt_make_contig(element_size),
+                                         tag * mpi_size + mpi_rank,
+                                         (ucp_send_callback_t)empty_callback_func);
 
-    CHECK_ERROR(UCS_PTR_IS_ERR(req), false, "ucp_tag_send_nb");
+  CHECK_ERROR(UCS_PTR_IS_ERR(req), false, "ucp_tag_send_nb");
 
-    if (UCS_PTR_STATUS(req) == UCS_OK) {
-        // already locally completed
-        return nullptr;
-    } else {
-        return req;
-    }
+  if (UCS_PTR_STATUS(req) == UCS_OK) {
+    // already locally completed
+    return nullptr;
+  } else {
+    return req;
+  }
 }
-
 
 comm_handle_t UCXCommunicator::recv(void *buf, int64_t count, int element_size, int source, int tag)
 {
-    // TODO: the design of the communication tag should be in line with the design of UCXBufferCommunicator
-    ucs_status_ptr_t req = ucp_tag_recv_nb(
-        ucp_worker, buf, count, ucp_dt_make_contig(element_size),
-        tag * mpi_size + source, (ucp_tag_t)-1, (ucp_tag_recv_callback_t) empty_callback_func
-    );
+  // TODO: the design of the communication tag should be in line with the design of
+  // UCXBufferCommunicator
+  ucs_status_ptr_t req = ucp_tag_recv_nb(ucp_worker,
+                                         buf,
+                                         count,
+                                         ucp_dt_make_contig(element_size),
+                                         tag * mpi_size + source,
+                                         (ucp_tag_t)-1,
+                                         (ucp_tag_recv_callback_t)empty_callback_func);
 
-    CHECK_ERROR(UCS_PTR_IS_ERR(req), false, "ucp_tag_msg_recv_nb");
+  CHECK_ERROR(UCS_PTR_IS_ERR(req), false, "ucp_tag_msg_recv_nb");
 
-    return req;
+  return req;
 }
 
-
-comm_handle_t UCXCommunicator::recv(void **buf, int64_t *count, int element_size, int source, int tag)
+comm_handle_t UCXCommunicator::recv(
+  void **buf, int64_t *count, int element_size, int source, int tag)
 {
-    ucp_tag_message_h ucp_tag_message;
-    ucp_tag_recv_info_t ucp_probe_info;
+  ucp_tag_message_h ucp_tag_message;
+  ucp_tag_recv_info_t ucp_probe_info;
 
-    /* Probe the size of the incoming message */
+  /* Probe the size of the incoming message */
 
-    while (true) {
-        ucp_tag_message = ucp_tag_probe_nb(ucp_worker, tag * mpi_size + source, (ucp_tag_t) -1, 1, &ucp_probe_info);
+  while (true) {
+    ucp_tag_message =
+      ucp_tag_probe_nb(ucp_worker, tag * mpi_size + source, (ucp_tag_t)-1, 1, &ucp_probe_info);
 
-        if (ucp_tag_message != NULL) {
-            // the message has already arrived
-            break;
-        }
-
-        ucp_worker_progress(ucp_worker);
+    if (ucp_tag_message != NULL) {
+      // the message has already arrived
+      break;
     }
 
-    /* Allocate receive buffer */
+    ucp_worker_progress(ucp_worker);
+  }
 
-    *buf = rmm::mr::get_current_device_resource()->allocate(ucp_probe_info.length, cudaStreamDefault);
-    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
+  /* Allocate receive buffer */
 
-    /* Received data */
+  *buf = rmm::mr::get_current_device_resource()->allocate(ucp_probe_info.length, cudaStreamDefault);
+  CUDA_RT_CALL(cudaStreamSynchronize(cudaStreamDefault));
 
-    ucs_status_ptr_t req = ucp_tag_msg_recv_nb(
-        ucp_worker, *buf, ucp_probe_info.length / element_size,
-        ucp_dt_make_contig(element_size), ucp_tag_message, (ucp_tag_recv_callback_t) empty_callback_func
-    );
+  /* Received data */
 
-    CHECK_ERROR(UCS_PTR_IS_ERR(req), false, "ucp_tag_msg_recv_nb");
+  ucs_status_ptr_t req = ucp_tag_msg_recv_nb(ucp_worker,
+                                             *buf,
+                                             ucp_probe_info.length / element_size,
+                                             ucp_dt_make_contig(element_size),
+                                             ucp_tag_message,
+                                             (ucp_tag_recv_callback_t)empty_callback_func);
 
-    if (count != nullptr)
-        *count = ucp_probe_info.length / element_size;
+  CHECK_ERROR(UCS_PTR_IS_ERR(req), false, "ucp_tag_msg_recv_nb");
 
-    return req;
+  if (count != nullptr) *count = ucp_probe_info.length / element_size;
+
+  return req;
 }
 
-
-void UCXCommunicator::register_buffer(void *buf, size_t size, ucp_mem_h* memory_handle)
+void UCXCommunicator::register_buffer(void *buf, size_t size, ucp_mem_h *memory_handle)
 {
-    ucp_mem_map_params_t mem_map_params;
-    memset(&mem_map_params, 0, sizeof(ucp_mem_map_params_t));
-    mem_map_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS | UCP_MEM_MAP_PARAM_FIELD_LENGTH;
-    mem_map_params.address    = buf;
-    mem_map_params.length     = size;
+  ucp_mem_map_params_t mem_map_params;
+  memset(&mem_map_params, 0, sizeof(ucp_mem_map_params_t));
+  mem_map_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS | UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+  mem_map_params.address    = buf;
+  mem_map_params.length     = size;
 
-    UCX_CALL( ucp_mem_map(ucp_context, &mem_map_params, memory_handle) );
+  UCX_CALL(ucp_mem_map(ucp_context, &mem_map_params, memory_handle));
 }
-
 
 void UCXCommunicator::deregister_buffer(ucp_mem_h memory_handle)
 {
-    UCX_CALL( ucp_mem_unmap(ucp_context, memory_handle) );
+  UCX_CALL(ucp_mem_unmap(ucp_context, memory_handle));
 }
-
 
 void UCXCommunicator::wait(comm_handle_t request)
 {
-    ucs_status_t ucx_status;
+  ucs_status_t ucx_status;
 
-    if (request == nullptr)
-        return;
+  if (request == nullptr) return;
 
-    while (true) {
-        ucx_status = ucp_request_check_status(request);
-        if (ucx_status == UCS_INPROGRESS) {
-            ucp_worker_progress(ucp_worker);
-            continue;
-        }
-
-        UCX_CALL(ucx_status);
-        break;
+  while (true) {
+    ucx_status = ucp_request_check_status(request);
+    if (ucx_status == UCS_INPROGRESS) {
+      ucp_worker_progress(ucp_worker);
+      continue;
     }
 
-    if (request != nullptr)
-        ucp_request_free(request);
-}
+    UCX_CALL(ucx_status);
+    break;
+  }
 
+  if (request != nullptr) ucp_request_free(request);
+}
 
 void UCXCommunicator::waitall(std::vector<comm_handle_t> requests)
 {
-    UCXCommunicator::waitall(requests.begin(), requests.end());
+  UCXCommunicator::waitall(requests.begin(), requests.end());
 }
 
-
-void UCXCommunicator::waitall(
-                              std::vector<comm_handle_t>::const_iterator begin,
+void UCXCommunicator::waitall(std::vector<comm_handle_t>::const_iterator begin,
                               std::vector<comm_handle_t>::const_iterator end)
 {
-    ucs_status_t ucx_status;
+  ucs_status_t ucx_status;
 
-    while (true) {
-        bool all_finished = true;
-
-        for (auto it = begin; it != end; it++) {
-            auto & request = *it;
-            if (request == nullptr)
-                continue;
-
-            ucx_status = ucp_request_check_status(request);
-
-            if (ucx_status == UCS_INPROGRESS) {
-                all_finished = false;
-                break;
-            }
-
-            UCX_CALL(ucx_status);
-        }
-
-        if (all_finished)
-            break;
-
-        ucp_worker_progress(ucp_worker);
-    }
+  while (true) {
+    bool all_finished = true;
 
     for (auto it = begin; it != end; it++) {
-        auto & request = *it;
-        if (request != nullptr)
-            ucp_request_free(request);
-    }
-}
+      auto &request = *it;
+      if (request == nullptr) continue;
 
+      ucx_status = ucp_request_check_status(request);
+
+      if (ucx_status == UCS_INPROGRESS) {
+        all_finished = false;
+        break;
+      }
+
+      UCX_CALL(ucx_status);
+    }
+
+    if (all_finished) break;
+
+    ucp_worker_progress(ucp_worker);
+  }
+
+  for (auto it = begin; it != end; it++) {
+    auto &request = *it;
+    if (request != nullptr) ucp_request_free(request);
+  }
+}
 
 void UCXCommunicator::finalize()
 {
-    std::vector<comm_handle_t> close_nb_reqs(mpi_size, nullptr);
+  std::vector<comm_handle_t> close_nb_reqs(mpi_size, nullptr);
 
-    for (int irank = 0; irank < mpi_size; irank++) {
-        ucs_status_ptr_t ucs_status_ptr = ucp_ep_close_nb(ucp_endpoints[irank], UCP_EP_CLOSE_MODE_FLUSH);
+  for (int irank = 0; irank < mpi_size; irank++) {
+    ucs_status_ptr_t ucs_status_ptr =
+      ucp_ep_close_nb(ucp_endpoints[irank], UCP_EP_CLOSE_MODE_FLUSH);
 
-        CHECK_ERROR(UCS_PTR_IS_ERR(ucs_status_ptr), false, "ucp_ep_close_nb");
+    CHECK_ERROR(UCS_PTR_IS_ERR(ucs_status_ptr), false, "ucp_ep_close_nb");
 
-        if (UCS_PTR_STATUS(ucs_status_ptr) != UCS_OK)
-            close_nb_reqs[irank] = ucs_status_ptr;
-    }
+    if (UCS_PTR_STATUS(ucs_status_ptr) != UCS_OK) close_nb_reqs[irank] = ucs_status_ptr;
+  }
 
-    UCXCommunicator::waitall(close_nb_reqs);
+  UCXCommunicator::waitall(close_nb_reqs);
 
-    // Barrier is necessary here because we do not want to destroy any worker before all ranks have closed the
-    // endpoints.
-    MPI_Barrier(MPI_COMM_WORLD);
+  // Barrier is necessary here because we do not want to destroy any worker before all ranks have
+  // closed the endpoints.
+  MPI_Barrier(MPI_COMM_WORLD);
 
-    ucp_worker_release_address(ucp_worker, ucp_worker_address);
-    ucp_worker_destroy(ucp_worker);
-    ucp_cleanup(ucp_context);
+  ucp_worker_release_address(ucp_worker, ucp_worker_address);
+  ucp_worker_destroy(ucp_worker);
+  ucp_cleanup(ucp_context);
 }
-
 
 static void request_init(void *request)
 {
-    UCXBufferCommunicator::CommInfo *info = (UCXBufferCommunicator::CommInfo *) request;
-    info->completed = false;
-    info->comm = nullptr;
-    info->orig_info = nullptr;
-    info->custom_allocated = false;
+  UCXBufferCommunicator::CommInfo *info = (UCXBufferCommunicator::CommInfo *)request;
+  info->completed                       = false;
+  info->comm                            = nullptr;
+  info->orig_info                       = nullptr;
+  info->custom_allocated                = false;
 }
-
 
 void UCXBufferCommunicator::initialize_ucx()
 {
-    // Note: This initialization is different from UCXCommunicator on requesting reserved space in
-    // the communication handle.
+  // Note: This initialization is different from UCXCommunicator on requesting reserved space in
+  // the communication handle.
 
-    ucp_params_t        ucp_params;
-    ucp_config_t        *ucp_config;
-    ucp_worker_params_t ucp_worker_params;
+  ucp_params_t ucp_params;
+  ucp_config_t *ucp_config;
+  ucp_worker_params_t ucp_worker_params;
 
-    assert(sizeof(SendInfo) == sizeof(RecvInfo));
+  assert(sizeof(SendInfo) == sizeof(RecvInfo));
 
-    memset(&ucp_params, 0, sizeof(ucp_params));
-    ucp_params.field_mask        = UCP_PARAM_FIELD_FEATURES |
-                                   UCP_PARAM_FIELD_ESTIMATED_NUM_EPS |
-                                   UCP_PARAM_FIELD_REQUEST_INIT |
-                                   UCP_PARAM_FIELD_REQUEST_SIZE;
+  memset(&ucp_params, 0, sizeof(ucp_params));
+  ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_ESTIMATED_NUM_EPS |
+                          UCP_PARAM_FIELD_REQUEST_INIT | UCP_PARAM_FIELD_REQUEST_SIZE;
 
-    ucp_params.features          = UCP_FEATURE_TAG;
-    ucp_params.estimated_num_eps = mpi_size;
-    ucp_params.request_size      = sizeof(SendInfo);
-    ucp_params.request_init      = request_init;
+  ucp_params.features          = UCP_FEATURE_TAG;
+  ucp_params.estimated_num_eps = mpi_size;
+  ucp_params.request_size      = sizeof(SendInfo);
+  ucp_params.request_init      = request_init;
 
-    UCX_CALL(ucp_config_read(NULL, NULL, &ucp_config));
+  UCX_CALL(ucp_config_read(NULL, NULL, &ucp_config));
 
-    UCX_CALL(ucp_init(&ucp_params, ucp_config, &ucp_context));
-    ucp_config_release(ucp_config);
+  UCX_CALL(ucp_init(&ucp_params, ucp_config, &ucp_context));
+  ucp_config_release(ucp_config);
 
-    memset(&ucp_worker_params, 0, sizeof(ucp_worker_params));
-    ucp_worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
-    ucp_worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;  // only the master thread can access UCX
+  memset(&ucp_worker_params, 0, sizeof(ucp_worker_params));
+  ucp_worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+  ucp_worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;  // only the master thread can access UCX
 
-    UCX_CALL(ucp_worker_create(ucp_context, &ucp_worker_params, &ucp_worker));
+  UCX_CALL(ucp_worker_create(ucp_context, &ucp_worker_params, &ucp_worker));
 
-    UCX_CALL(ucp_worker_get_address(ucp_worker, &ucp_worker_address, &ucp_worker_address_len));
+  UCX_CALL(ucp_worker_get_address(ucp_worker, &ucp_worker_address, &ucp_worker_address_len));
 }
-
 
 void UCXBufferCommunicator::initialize()
 {
-    UCXCommunicator::initialize();
+  UCXCommunicator::initialize();
 
-    if (mpi_size > 65536) {
-        throw std::runtime_error("Ranks > 65536 is not supported due to tag limitation");
-    }
+  if (mpi_size > 65536) {
+    throw std::runtime_error("Ranks > 65536 is not supported due to tag limitation");
+  }
 
-    /* Create priority stream for copying between user buffer and comm buffer. Useful for overlapping. */
+  /* Create priority stream for copying between user buffer and comm buffer. Useful for overlapping.
+   */
 
-    int least_priority;
-    int greatest_priority;
+  int least_priority;
+  int greatest_priority;
 
-    CUDA_RT_CALL( cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority) );
+  CUDA_RT_CALL(cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority));
 
-    CUDA_RT_CALL( cudaStreamCreateWithPriority(&copy_stream, cudaStreamNonBlocking, greatest_priority) );
+  CUDA_RT_CALL(
+    cudaStreamCreateWithPriority(&copy_stream, cudaStreamNonBlocking, greatest_priority));
 }
-
 
 void UCXBufferCommunicator::setup_cache(int64_t ncaches, int64_t buffer_size)
 {
-    comm_buffer_size = buffer_size;
-    cache_start_addr = rmm::mr::get_current_device_resource()->allocate(
-        comm_buffer_size * ncaches, cudaStreamDefault
-    );
-    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
+  comm_buffer_size = buffer_size;
+  cache_start_addr =
+    rmm::mr::get_current_device_resource()->allocate(comm_buffer_size * ncaches, cudaStreamDefault);
+  CUDA_RT_CALL(cudaStreamSynchronize(cudaStreamDefault));
 
-    register_buffer(cache_start_addr, comm_buffer_size * ncaches, &cache_mem_handle);
+  register_buffer(cache_start_addr, comm_buffer_size * ncaches, &cache_mem_handle);
 
-    for (int icache = 0; icache < ncaches; icache ++) {
-        void *current_buffer = (void *)((char *)cache_start_addr + icache * buffer_size);
-        buffer_cache.push(current_buffer);
-    }
+  for (int icache = 0; icache < ncaches; icache++) {
+    void *current_buffer = (void *)((char *)cache_start_addr + icache * buffer_size);
+    buffer_cache.push(current_buffer);
+  }
 }
-
 
 /**
  * Get the communication tag passed to UCX from user defined tag and source rank.
@@ -417,498 +386,487 @@ void UCXBufferCommunicator::setup_cache(int64_t ncaches, int64_t buffer_size)
  */
 uint64_t get_comm_tag(int user_tag, int source_rank)
 {
-    uint64_t comm_tag = 0LLU;
-    // user_tag occupies the most significant 32 bits of comm_tag
-    comm_tag |= ((uint64_t)user_tag << 32);
-    // source rank occupies the least significant 32 bits of comm_tag
-    comm_tag |= (uint64_t)source_rank;
+  uint64_t comm_tag = 0LLU;
+  // user_tag occupies the most significant 32 bits of comm_tag
+  comm_tag |= ((uint64_t)user_tag << 32);
+  // source rank occupies the least significant 32 bits of comm_tag
+  comm_tag |= (uint64_t)source_rank;
 
-    return comm_tag;
+  return comm_tag;
 }
-
 
 static void send_handler(void *request, ucs_status_t status)
 {
-    UCXBufferCommunicator::SendInfo *info = (UCXBufferCommunicator::SendInfo *)request;
-    int element_size = info->element_size;
-    int ibatch = info->ibatch;
+  UCXBufferCommunicator::SendInfo *info = (UCXBufferCommunicator::SendInfo *)request;
+  int element_size                      = info->element_size;
+  int ibatch                            = info->ibatch;
 
-    const int64_t nelements_per_batch = info->comm->comm_buffer_size / element_size;
+  const int64_t nelements_per_batch = info->comm->comm_buffer_size / element_size;
 
-    int64_t nelements_remaining = *(info->count) - nelements_per_batch * ibatch;
+  int64_t nelements_remaining = *(info->count) - nelements_per_batch * ibatch;
 
-    request = nullptr;
+  request = nullptr;
 
-    while (nelements_remaining > 0) {
-        int64_t nelements_current_batch = (nelements_remaining < nelements_per_batch ?
-                                          nelements_remaining : nelements_per_batch);
-        int64_t nelements_sent = ibatch * nelements_per_batch;
-        void *start_addr = (void *)((char *)info->send_buffer + nelements_sent * element_size);
+  while (nelements_remaining > 0) {
+    int64_t nelements_current_batch =
+      (nelements_remaining < nelements_per_batch ? nelements_remaining : nelements_per_batch);
+    int64_t nelements_sent = ibatch * nelements_per_batch;
+    void *start_addr       = (void *)((char *)info->send_buffer + nelements_sent * element_size);
 
-        /* Copy data from user buffer to the communication buffer */
+    /* Copy data from user buffer to the communication buffer */
 
-        CUDA_RT_CALL(cudaMemcpyAsync(
-            info->comm_buffer, start_addr, nelements_current_batch * element_size, cudaMemcpyDeviceToDevice,
-            info->comm->copy_stream
-        ));
+    CUDA_RT_CALL(cudaMemcpyAsync(info->comm_buffer,
+                                 start_addr,
+                                 nelements_current_batch * element_size,
+                                 cudaMemcpyDeviceToDevice,
+                                 info->comm->copy_stream));
 
-        CUDA_RT_CALL(cudaStreamSynchronize(info->comm->copy_stream));
+    CUDA_RT_CALL(cudaStreamSynchronize(info->comm->copy_stream));
 
-        /* Construct communication tag */
+    /* Construct communication tag */
 
-        uint64_t comm_tag = get_comm_tag(info->user_tag, info->comm->mpi_rank);
+    uint64_t comm_tag = get_comm_tag(info->user_tag, info->comm->mpi_rank);
 
-        /* Send the communication buffer to the remote rank */
+    /* Send the communication buffer to the remote rank */
 
-        request = ucp_tag_send_nb(
-            info->comm->ucp_endpoints[info->dest], info->comm_buffer,
-            nelements_current_batch, ucp_dt_make_contig(element_size),
-            comm_tag, send_handler
-        );
-
-        CHECK_ERROR(UCS_PTR_IS_ERR(request), false, "ucp_tag_send_nb");
-
-        if (UCS_PTR_STATUS(request) != UCS_OK) {
-            // Send is not complete for now. Subsequent batches are handled by continuation.
-            break;
-        }
-
-        request = nullptr;
-        ibatch++;
-        nelements_remaining -= nelements_current_batch;
-    }
-
-    if (request != nullptr) {
-        // Copy info from the handle of last batch to the handle of the current batch
-        memcpy(request, info, sizeof(UCXBufferCommunicator::SendInfo));
-        ((UCXBufferCommunicator::SendInfo *)request)->ibatch = ibatch + 1;
-        ((UCXBufferCommunicator::SendInfo *)request)->custom_allocated = false;
-    } else {
-        info->orig_info->completed = true;
-    }
-
-    // Free the request handle if it is internal (not returned to user)
-    if ((void *)info != (void *)(info->orig_info)) {
-        // This handle is internal and no longer needed. Free it.
-        info->completed = false;
-        info->comm = nullptr;
-        info->orig_info = nullptr;
-        info->custom_allocated = false;
-        ucp_request_free(info);
-    }
-}
-
-
-comm_handle_t UCXBufferCommunicator::send(const void *buf, int64_t count, int element_size, int dest, int tag)
-{
-    // Get the communication tag for sending the number of elements (count)
-    uint64_t comm_tag = get_comm_tag(tag, mpi_rank);
-
-    // Since send operation is fully async to the user, we need to keep the count buffer alive
-    int64_t *count_buf = (int64_t *)malloc(sizeof(int64_t));  // TODO: never freed?
-    *count_buf = count;
-
-    // Send the buffer size. This is needed because the receive side may not have information on how large the buffer
-    // is.
-    comm_handle_t request = ucp_tag_send_nb(
-        ucp_endpoints[dest], count_buf, 1, ucp_dt_make_contig(sizeof(int64_t)), comm_tag, send_handler
-    );
+    request = ucp_tag_send_nb(info->comm->ucp_endpoints[info->dest],
+                              info->comm_buffer,
+                              nelements_current_batch,
+                              ucp_dt_make_contig(element_size),
+                              comm_tag,
+                              send_handler);
 
     CHECK_ERROR(UCS_PTR_IS_ERR(request), false, "ucp_tag_send_nb");
 
-    if (UCS_PTR_STATUS(request) == UCS_OK) {
-        // Sending buffer size is completed locally. Allocate request handle manually.
-        request = malloc(sizeof(SendInfo));
-        ((SendInfo *)request)->custom_allocated = true;
-        ((SendInfo *)request)->completed = false;
+    if (UCS_PTR_STATUS(request) != UCS_OK) {
+      // Send is not complete for now. Subsequent batches are handled by continuation.
+      break;
     }
 
-    // Get the communication buffer
-    if (buffer_cache.empty()) {
-        // TODO: A better way to implement this would print a warning and fallback to normal send.
-        throw std::runtime_error("No buffered cache available");
-    }
+    request = nullptr;
+    ibatch++;
+    nelements_remaining -= nelements_current_batch;
+  }
 
-    void *comm_buffer = buffer_cache.front();
-    buffer_cache.pop();
+  if (request != nullptr) {
+    // Copy info from the handle of last batch to the handle of the current batch
+    memcpy(request, info, sizeof(UCXBufferCommunicator::SendInfo));
+    ((UCXBufferCommunicator::SendInfo *)request)->ibatch           = ibatch + 1;
+    ((UCXBufferCommunicator::SendInfo *)request)->custom_allocated = false;
+  } else {
+    info->orig_info->completed = true;
+  }
 
-    // Fill in information about this send in the request handle so that the callback can launch subsequent batches.
-    SendInfo *info = (SendInfo *)request;
-    info->types = SEND;
-    info->send_buffer = buf;
-    info->comm_buffer = comm_buffer;
-    info->count = count_buf;
-    info->element_size = element_size;
-    info->dest = dest;
-    info->user_tag = tag;
-    info->ibatch = 0;
-    info->comm = this;
-    info->orig_info = (UCXBufferCommunicator::CommInfo *)info;
-
-    if (info->custom_allocated) {
-        // Launch callback manually
-        send_handler(request, UCS_OK);
-    }
-
-    return request;
-}
-
-
-static void recv_handler(void *request, ucs_status_t status,
-                         ucp_tag_recv_info_t *recv_info)
-{
-    UCXBufferCommunicator::RecvInfo *info = (UCXBufferCommunicator::RecvInfo *)request;
-
-    if (info->orig_info == nullptr) {
-        // If the code enters here, it means the callback has been called by UCX but the necessary information in the
-        // request handle hasn't been filled yet. We will mark 'orig_info' here, the receive will fill the information
-        // and this callback will be manually called again.
-        info->orig_info = (UCXBufferCommunicator::CommInfo*) 0x1;
-        return;
-    }
-
-    int element_size = info->element_size;
-    const int64_t nelements_per_batch = info->comm->comm_buffer_size / element_size;
-
-    /* Allocate receive buffer if not available */
-
-    if (*(info->recv_buffer) == nullptr && *(info->count) > 0) {
-        assert(info->ibatch == 0);
-        *(info->recv_buffer) = rmm::mr::get_current_device_resource()->allocate(
-            *(info->count) * element_size, cudaStreamDefault
-        );
-        CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
-    }
-
-    /* Copy data from communication buffer to user buffer for the finished batch */
-
-    if (info->ibatch > 0) {
-        // Calculate the start address of the user buffer of the finished batch
-        int last_batch = info->ibatch - 1;
-        int64_t nelement_copied = nelements_per_batch * last_batch;
-        int64_t nelements_uncopied = *(info->count) - nelement_copied;
-        int64_t nelements_copy_batch = (nelements_uncopied < nelements_per_batch ?
-                                       nelements_uncopied : nelements_per_batch);
-
-        void *start_addr = (void *)((char *)(*(info->recv_buffer)) + nelement_copied * element_size);
-
-        // Copy data from comm buffer to user buffer
-        CUDA_RT_CALL(cudaMemcpyAsync(
-            start_addr, info->comm_buffer, nelements_copy_batch * element_size, cudaMemcpyDeviceToDevice,
-            info->comm->copy_stream
-        ));
-
-        CUDA_RT_CALL(cudaStreamSynchronize(info->comm->copy_stream));
-    }
-
-    /* Recv data from remote rank for the next batch */
-
-    int64_t nelement_recved = nelements_per_batch * info->ibatch;
-    int64_t nelements_remaining = *(info->count) - nelement_recved;
-    int64_t nelements_current_batch = (nelements_remaining < nelements_per_batch ?
-                                       nelements_remaining : nelements_per_batch);
-
-    if (nelements_current_batch > 0) {
-        uint64_t comm_tag = get_comm_tag(info->user_tag, info->source);
-
-        request = ucp_tag_recv_nb(
-            info->comm->ucp_worker, info->comm_buffer, nelements_current_batch, ucp_dt_make_contig(element_size),
-            comm_tag, (ucp_tag_t)-1, recv_handler
-        );
-
-        CHECK_ERROR(UCS_PTR_IS_ERR(request), false, "ucp_tag_recv_nb");
-
-        // It is possible the callback is called inside 'ucp_tag_recv_nb' but the necessary information hasn't been
-        // filled in the request handle. In that case, this function will manually call the callback again after filling
-        // the request handle.
-        bool callback_called = (((UCXBufferCommunicator::RecvInfo *)request)->orig_info != nullptr);
-
-        // Fill the request handle of the next batch with the same info of this batch but add 1 to info->ibatch
-        (info->ibatch)++;
-        memcpy(request, info, sizeof(UCXBufferCommunicator::RecvInfo));
-
-        if (callback_called) {
-            // Call the callback manually
-            recv_handler(request, UCS_OK, nullptr);
-        }
-    } else {
-        info->orig_info->completed = true;
-    }
-
-    // Free the request handle if it is internal (not returned to user)
-    if ((void *)info != (void *)(info->orig_info)) {
-        info->completed = false;
-        info->comm = nullptr;
-        info->orig_info = nullptr;
-        info->custom_allocated = false;
-        ucp_request_free(info);
-    }
-}
-
-
-comm_handle_t UCXBufferCommunicator::recv_helper(void **buf, int64_t *count, int element_size, int source, int tag)
-{
-    // Allocate the receive buffer for receiving message size
-    int64_t* recved_count;
-
-    if (count == nullptr)
-        recved_count = (int64_t *)malloc(sizeof(int64_t));  // TODO: memory leak, never freed?
-    else
-        recved_count = count;
-
-    // Construct tag for receiving the number of elements
-    uint64_t comm_tag = get_comm_tag(tag, source);
-
-    // Request to receive the message size
-    ucs_status_ptr_t request = ucp_tag_recv_nb(
-        ucp_worker, recved_count, 1, ucp_dt_make_contig(sizeof(int64_t)),
-        comm_tag, (ucp_tag_t)-1, recv_handler
-    );
-
-    CHECK_ERROR(UCS_PTR_IS_ERR(request), false, "ucp_tag_msg_recv_nb");
-
-    // Get the communication buffer
-    if (buffer_cache.empty()) {
-        // TODO: A better way to implement this would print a warning and fallback to normal send.
-        throw std::runtime_error("No buffered cache available");
-    }
-
-    void *comm_buffer = buffer_cache.front();
-    buffer_cache.pop();
-
-    // Fill information inside communication handle so that the callbacks can use this to receive subsequent batches
-    RecvInfo *info = (RecvInfo *)request;
-    // Mark callback_called as true if the message size is received inside ucp_tag_recv_nb
-    bool callback_called = (info->orig_info != nullptr);
-
-    info->types = RECV;
-
-    if (*buf == nullptr) {
-        info->recv_buffer = buf;
-    } else {
-        info->recv_buffer = (void **)malloc(sizeof(void *));  // TODO: never freed, memory leak.
-        *(info->recv_buffer) = *buf;
-    }
-
-    info->comm_buffer = comm_buffer;
+  // Free the request handle if it is internal (not returned to user)
+  if ((void *)info != (void *)(info->orig_info)) {
+    // This handle is internal and no longer needed. Free it.
+    info->completed        = false;
+    info->comm             = nullptr;
+    info->orig_info        = nullptr;
     info->custom_allocated = false;
-    info->count = recved_count;
-    info->element_size = element_size;
-    info->source = source;
-    info->user_tag = tag;
-    info->ibatch = 0;
-    info->comm = this;
-    info->orig_info = (UCXBufferCommunicator::CommInfo *)info;
+    ucp_request_free(info);
+  }
+}
+
+comm_handle_t UCXBufferCommunicator::send(
+  const void *buf, int64_t count, int element_size, int dest, int tag)
+{
+  // Get the communication tag for sending the number of elements (count)
+  uint64_t comm_tag = get_comm_tag(tag, mpi_rank);
+
+  // Since send operation is fully async to the user, we need to keep the count buffer alive
+  int64_t *count_buf = (int64_t *)malloc(sizeof(int64_t));  // TODO: never freed?
+  *count_buf         = count;
+
+  // Send the buffer size. This is needed because the receive side may not have information on how
+  // large the buffer is.
+  comm_handle_t request = ucp_tag_send_nb(
+    ucp_endpoints[dest], count_buf, 1, ucp_dt_make_contig(sizeof(int64_t)), comm_tag, send_handler);
+
+  CHECK_ERROR(UCS_PTR_IS_ERR(request), false, "ucp_tag_send_nb");
+
+  if (UCS_PTR_STATUS(request) == UCS_OK) {
+    // Sending buffer size is completed locally. Allocate request handle manually.
+    request                                 = malloc(sizeof(SendInfo));
+    ((SendInfo *)request)->custom_allocated = true;
+    ((SendInfo *)request)->completed        = false;
+  }
+
+  // Get the communication buffer
+  if (buffer_cache.empty()) {
+    // TODO: A better way to implement this would print a warning and fallback to normal send.
+    throw std::runtime_error("No buffered cache available");
+  }
+
+  void *comm_buffer = buffer_cache.front();
+  buffer_cache.pop();
+
+  // Fill in information about this send in the request handle so that the callback can launch
+  // subsequent batches.
+  SendInfo *info     = (SendInfo *)request;
+  info->types        = SEND;
+  info->send_buffer  = buf;
+  info->comm_buffer  = comm_buffer;
+  info->count        = count_buf;
+  info->element_size = element_size;
+  info->dest         = dest;
+  info->user_tag     = tag;
+  info->ibatch       = 0;
+  info->comm         = this;
+  info->orig_info    = (UCXBufferCommunicator::CommInfo *)info;
+
+  if (info->custom_allocated) {
+    // Launch callback manually
+    send_handler(request, UCS_OK);
+  }
+
+  return request;
+}
+
+static void recv_handler(void *request, ucs_status_t status, ucp_tag_recv_info_t *recv_info)
+{
+  UCXBufferCommunicator::RecvInfo *info = (UCXBufferCommunicator::RecvInfo *)request;
+
+  if (info->orig_info == nullptr) {
+    // If the code enters here, it means the callback has been called by UCX but the necessary
+    // information in the request handle hasn't been filled yet. We will mark 'orig_info' here, the
+    // receive will fill the information and this callback will be manually called again.
+    info->orig_info = (UCXBufferCommunicator::CommInfo *)0x1;
+    return;
+  }
+
+  int element_size                  = info->element_size;
+  const int64_t nelements_per_batch = info->comm->comm_buffer_size / element_size;
+
+  /* Allocate receive buffer if not available */
+
+  if (*(info->recv_buffer) == nullptr && *(info->count) > 0) {
+    assert(info->ibatch == 0);
+    *(info->recv_buffer) = rmm::mr::get_current_device_resource()->allocate(
+      *(info->count) * element_size, cudaStreamDefault);
+    CUDA_RT_CALL(cudaStreamSynchronize(cudaStreamDefault));
+  }
+
+  /* Copy data from communication buffer to user buffer for the finished batch */
+
+  if (info->ibatch > 0) {
+    // Calculate the start address of the user buffer of the finished batch
+    int last_batch             = info->ibatch - 1;
+    int64_t nelement_copied    = nelements_per_batch * last_batch;
+    int64_t nelements_uncopied = *(info->count) - nelement_copied;
+    int64_t nelements_copy_batch =
+      (nelements_uncopied < nelements_per_batch ? nelements_uncopied : nelements_per_batch);
+
+    void *start_addr = (void *)((char *)(*(info->recv_buffer)) + nelement_copied * element_size);
+
+    // Copy data from comm buffer to user buffer
+    CUDA_RT_CALL(cudaMemcpyAsync(start_addr,
+                                 info->comm_buffer,
+                                 nelements_copy_batch * element_size,
+                                 cudaMemcpyDeviceToDevice,
+                                 info->comm->copy_stream));
+
+    CUDA_RT_CALL(cudaStreamSynchronize(info->comm->copy_stream));
+  }
+
+  /* Recv data from remote rank for the next batch */
+
+  int64_t nelement_recved     = nelements_per_batch * info->ibatch;
+  int64_t nelements_remaining = *(info->count) - nelement_recved;
+  int64_t nelements_current_batch =
+    (nelements_remaining < nelements_per_batch ? nelements_remaining : nelements_per_batch);
+
+  if (nelements_current_batch > 0) {
+    uint64_t comm_tag = get_comm_tag(info->user_tag, info->source);
+
+    request = ucp_tag_recv_nb(info->comm->ucp_worker,
+                              info->comm_buffer,
+                              nelements_current_batch,
+                              ucp_dt_make_contig(element_size),
+                              comm_tag,
+                              (ucp_tag_t)-1,
+                              recv_handler);
+
+    CHECK_ERROR(UCS_PTR_IS_ERR(request), false, "ucp_tag_recv_nb");
+
+    // It is possible the callback is called inside 'ucp_tag_recv_nb' but the necessary information
+    // hasn't been filled in the request handle. In that case, this function will manually call the
+    // callback again after filling the request handle.
+    bool callback_called = (((UCXBufferCommunicator::RecvInfo *)request)->orig_info != nullptr);
+
+    // Fill the request handle of the next batch with the same info of this batch but add 1 to
+    // info->ibatch
+    (info->ibatch)++;
+    memcpy(request, info, sizeof(UCXBufferCommunicator::RecvInfo));
 
     if (callback_called) {
-        // Manually launch callback again if the callback is called inside ucp_tag_recv_nb
-        recv_handler(info, UCS_OK, nullptr);
+      // Call the callback manually
+      recv_handler(request, UCS_OK, nullptr);
     }
+  } else {
+    info->orig_info->completed = true;
+  }
 
-    return request;
+  // Free the request handle if it is internal (not returned to user)
+  if ((void *)info != (void *)(info->orig_info)) {
+    info->completed        = false;
+    info->comm             = nullptr;
+    info->orig_info        = nullptr;
+    info->custom_allocated = false;
+    ucp_request_free(info);
+  }
 }
 
-
-comm_handle_t UCXBufferCommunicator::recv(void *buf, int64_t count, int element_size, int source, int tag)
+comm_handle_t UCXBufferCommunicator::recv_helper(
+  void **buf, int64_t *count, int element_size, int source, int tag)
 {
-    return recv_helper(&buf, nullptr, element_size, source, tag);
+  // Allocate the receive buffer for receiving message size
+  int64_t *recved_count;
+
+  if (count == nullptr)
+    recved_count = (int64_t *)malloc(sizeof(int64_t));  // TODO: memory leak, never freed?
+  else
+    recved_count = count;
+
+  // Construct tag for receiving the number of elements
+  uint64_t comm_tag = get_comm_tag(tag, source);
+
+  // Request to receive the message size
+  ucs_status_ptr_t request = ucp_tag_recv_nb(ucp_worker,
+                                             recved_count,
+                                             1,
+                                             ucp_dt_make_contig(sizeof(int64_t)),
+                                             comm_tag,
+                                             (ucp_tag_t)-1,
+                                             recv_handler);
+
+  CHECK_ERROR(UCS_PTR_IS_ERR(request), false, "ucp_tag_msg_recv_nb");
+
+  // Get the communication buffer
+  if (buffer_cache.empty()) {
+    // TODO: A better way to implement this would print a warning and fallback to normal send.
+    throw std::runtime_error("No buffered cache available");
+  }
+
+  void *comm_buffer = buffer_cache.front();
+  buffer_cache.pop();
+
+  // Fill information inside communication handle so that the callbacks can use this to receive
+  // subsequent batches
+  RecvInfo *info = (RecvInfo *)request;
+  // Mark callback_called as true if the message size is received inside ucp_tag_recv_nb
+  bool callback_called = (info->orig_info != nullptr);
+
+  info->types = RECV;
+
+  if (*buf == nullptr) {
+    info->recv_buffer = buf;
+  } else {
+    info->recv_buffer    = (void **)malloc(sizeof(void *));  // TODO: never freed, memory leak.
+    *(info->recv_buffer) = *buf;
+  }
+
+  info->comm_buffer      = comm_buffer;
+  info->custom_allocated = false;
+  info->count            = recved_count;
+  info->element_size     = element_size;
+  info->source           = source;
+  info->user_tag         = tag;
+  info->ibatch           = 0;
+  info->comm             = this;
+  info->orig_info        = (UCXBufferCommunicator::CommInfo *)info;
+
+  if (callback_called) {
+    // Manually launch callback again if the callback is called inside ucp_tag_recv_nb
+    recv_handler(info, UCS_OK, nullptr);
+  }
+
+  return request;
 }
 
-
-comm_handle_t UCXBufferCommunicator::recv(void **buf, int64_t *count, int element_size, int source, int tag)
+comm_handle_t UCXBufferCommunicator::recv(
+  void *buf, int64_t count, int element_size, int source, int tag)
 {
-    // Set *buf to nullptr so that it's allocated inside callback
-    *buf = nullptr;
-
-    return recv_helper(buf, count, element_size, source, tag);
+  return recv_helper(&buf, nullptr, element_size, source, tag);
 }
 
+comm_handle_t UCXBufferCommunicator::recv(
+  void **buf, int64_t *count, int element_size, int source, int tag)
+{
+  // Set *buf to nullptr so that it's allocated inside callback
+  *buf = nullptr;
+
+  return recv_helper(buf, count, element_size, source, tag);
+}
 
 void UCXBufferCommunicator::wait(comm_handle_t request)
 {
-    CommInfo *info = (CommInfo *) request;
+  CommInfo *info = (CommInfo *)request;
 
-    if (info == nullptr)
-        return;
+  if (info == nullptr) return;
 
-    // Use busy polling for waiting for completion
-    while (info->completed == false) {
-        ucp_worker_progress(ucp_worker);
-    }
+  // Use busy polling for waiting for completion
+  while (info->completed == false) { ucp_worker_progress(ucp_worker); }
 
-    // Put the comm buffer back to the buffer queue
-    buffer_cache.push(info->comm_buffer);
+  // Put the comm buffer back to the buffer queue
+  buffer_cache.push(info->comm_buffer);
 
-    // Free the request handle
-    info->completed = false;
-    info->comm = nullptr;
-    info->orig_info = nullptr;
-    info->comm_buffer = nullptr;
+  // Free the request handle
+  info->completed   = false;
+  info->comm        = nullptr;
+  info->orig_info   = nullptr;
+  info->comm_buffer = nullptr;
 
-    if (info->custom_allocated)
-        free(request);
-    else
-        ucp_request_free(request);
+  if (info->custom_allocated)
+    free(request);
+  else
+    ucp_request_free(request);
 }
-
 
 void UCXBufferCommunicator::waitall(std::vector<comm_handle_t> requests)
 {
-    waitall(requests.begin(), requests.end());
+  waitall(requests.begin(), requests.end());
 }
 
-
-void UCXBufferCommunicator::waitall(std::vector<comm_handle_t>::const_iterator begin, std::vector<comm_handle_t>::const_iterator end)
+void UCXBufferCommunicator::waitall(std::vector<comm_handle_t>::const_iterator begin,
+                                    std::vector<comm_handle_t>::const_iterator end)
 {
-    // Use busy polling for waiting for all request handles
-    while (true) {
-        bool all_finished = true;
+  // Use busy polling for waiting for all request handles
+  while (true) {
+    bool all_finished = true;
 
-        for (auto it = begin; it != end; it++) {
-            CommInfo *request = (CommInfo *) *it;
-
-            if (request != nullptr && request->completed == false) {
-                all_finished = false;
-                break;
-            }
-        }
-
-        if (all_finished)
-            break;
-
-        ucp_worker_progress(ucp_worker);
-    }
-
-    // Put the comm buffers back to the buffer queue and free all request handles
     for (auto it = begin; it != end; it++) {
-        CommInfo *request = (CommInfo *) *it;
+      CommInfo *request = (CommInfo *)*it;
 
-        if (request != nullptr) {
-            buffer_cache.push(request->comm_buffer);
-            request->completed = false;
-            request->comm = nullptr;
-            request->orig_info = nullptr;
-            request->comm_buffer = nullptr;
-
-            if (request->custom_allocated)
-                free(request);
-            else
-                ucp_request_free(request);
-        }
+      if (request != nullptr && request->completed == false) {
+        all_finished = false;
+        break;
+      }
     }
-}
 
+    if (all_finished) break;
+
+    ucp_worker_progress(ucp_worker);
+  }
+
+  // Put the comm buffers back to the buffer queue and free all request handles
+  for (auto it = begin; it != end; it++) {
+    CommInfo *request = (CommInfo *)*it;
+
+    if (request != nullptr) {
+      buffer_cache.push(request->comm_buffer);
+      request->completed   = false;
+      request->comm        = nullptr;
+      request->orig_info   = nullptr;
+      request->comm_buffer = nullptr;
+
+      if (request->custom_allocated)
+        free(request);
+      else
+        ucp_request_free(request);
+    }
+  }
+}
 
 void UCXBufferCommunicator::finalize()
 {
-    deregister_buffer(cache_mem_handle);
-    rmm::mr::get_current_device_resource()->deallocate(
-        cache_start_addr, comm_buffer_size * buffer_cache.size(), cudaStreamDefault
-    );
-    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
-    UCXCommunicator::finalize();
+  deregister_buffer(cache_mem_handle);
+  rmm::mr::get_current_device_resource()->deallocate(
+    cache_start_addr, comm_buffer_size * buffer_cache.size(), cudaStreamDefault);
+  CUDA_RT_CALL(cudaStreamSynchronize(cudaStreamDefault));
+  UCXCommunicator::finalize();
 }
 
-
-UCXCommunicator* initialize_ucx_communicator(bool use_buffer_communicator,
+UCXCommunicator *initialize_ucx_communicator(bool use_buffer_communicator,
                                              int num_comm_buffers,
                                              int64_t comm_buffer_size)
 {
-    if (use_buffer_communicator) {
-        UCXBufferCommunicator *communicator = new UCXBufferCommunicator();
-        communicator->initialize();
-        communicator->setup_cache(num_comm_buffers, comm_buffer_size);
-        return communicator;
-    } else {
-        UCXCommunicator *communicator = new UCXCommunicator();
-        communicator->initialize();
-        return communicator;
-    }
+  if (use_buffer_communicator) {
+    UCXBufferCommunicator *communicator = new UCXBufferCommunicator();
+    communicator->initialize();
+    communicator->setup_cache(num_comm_buffers, comm_buffer_size);
+    return communicator;
+  } else {
+    UCXCommunicator *communicator = new UCXCommunicator();
+    communicator->initialize();
+    return communicator;
+  }
 }
-
 
 void NCCLCommunicator::initialize()
 {
-    Communicator::initialize();
+  Communicator::initialize();
 
-    ncclUniqueId nccl_id;
-    if (mpi_rank == 0)
-        NCCL_CALL( ncclGetUniqueId(&nccl_id) );
-    MPI_CALL( MPI_Bcast(&nccl_id, sizeof(nccl_id), MPI_BYTE, 0, MPI_COMM_WORLD) );
-    NCCL_CALL( ncclCommInitRank(&nccl_comm, mpi_size, nccl_id, mpi_rank) );
+  ncclUniqueId nccl_id;
+  if (mpi_rank == 0) NCCL_CALL(ncclGetUniqueId(&nccl_id));
+  MPI_CALL(MPI_Bcast(&nccl_id, sizeof(nccl_id), MPI_BYTE, 0, MPI_COMM_WORLD));
+  NCCL_CALL(ncclCommInitRank(&nccl_comm, mpi_size, nccl_id, mpi_rank));
 
-    CUDA_RT_CALL( cudaStreamCreate(&comm_stream) );
+  CUDA_RT_CALL(cudaStreamCreate(&comm_stream));
 }
-
 
 void NCCLCommunicator::start()
 {
-    NCCL_CALL( ncclGroupStart() );
-    comm_buffers.clear();
-    comm_buffer_sizes.clear();
-    recv_buffers.clear();
-    recv_buffer_idx.clear();
+  NCCL_CALL(ncclGroupStart());
+  comm_buffers.clear();
+  comm_buffer_sizes.clear();
+  recv_buffers.clear();
+  recv_buffer_idx.clear();
 }
-
 
 void NCCLCommunicator::send(const void *buf, int64_t count, int element_size, int dest)
 {
-    // Note: NCCL has performance issue when the buffer is not 128-bit aligned.
-    // This implementation gets away with issue by forcing the communication to go through a
-    // allocated communication buffer. This buffer is 256B aligned to be compatible with RMM.
-    std::size_t aligned_size = (count * element_size + 255) / 256 * 256;
+  // Note: NCCL has performance issue when the buffer is not 128-bit aligned.
+  // This implementation gets away with issue by forcing the communication to go through a
+  // allocated communication buffer. This buffer is 256B aligned to be compatible with RMM.
+  std::size_t aligned_size = (count * element_size + 255) / 256 * 256;
 
-    comm_buffers.push_back(
-        rmm::mr::get_current_device_resource()->allocate(aligned_size, comm_stream));
-    comm_buffer_sizes.push_back(count * element_size);
+  comm_buffers.push_back(
+    rmm::mr::get_current_device_resource()->allocate(aligned_size, comm_stream));
+  comm_buffer_sizes.push_back(count * element_size);
 
-    CUDA_RT_CALL(cudaMemcpyAsync(
-        comm_buffers.back(), buf, count * element_size, cudaMemcpyDeviceToDevice, comm_stream
-    ));
-    NCCL_CALL(ncclSend(comm_buffers.back(), aligned_size, ncclChar, dest, nccl_comm, comm_stream));
+  CUDA_RT_CALL(cudaMemcpyAsync(
+    comm_buffers.back(), buf, count * element_size, cudaMemcpyDeviceToDevice, comm_stream));
+  NCCL_CALL(ncclSend(comm_buffers.back(), aligned_size, ncclChar, dest, nccl_comm, comm_stream));
 }
-
 
 void NCCLCommunicator::recv(void *buf, int64_t count, int element_size, int source)
 {
-    std::size_t aligned_size = (count * element_size + 255) / 256 * 256;
+  std::size_t aligned_size = (count * element_size + 255) / 256 * 256;
 
-    recv_buffers.push_back(buf);
-    recv_buffer_idx.push_back(comm_buffers.size());
-    comm_buffers.push_back(
-        rmm::mr::get_current_device_resource()->allocate(aligned_size, comm_stream));
-    comm_buffer_sizes.push_back(count * element_size);
+  recv_buffers.push_back(buf);
+  recv_buffer_idx.push_back(comm_buffers.size());
+  comm_buffers.push_back(
+    rmm::mr::get_current_device_resource()->allocate(aligned_size, comm_stream));
+  comm_buffer_sizes.push_back(count * element_size);
 
-    NCCL_CALL(
-        ncclRecv(comm_buffers.back(), aligned_size, ncclChar, source, nccl_comm, comm_stream)
-    );
+  NCCL_CALL(ncclRecv(comm_buffers.back(), aligned_size, ncclChar, source, nccl_comm, comm_stream));
 }
-
 
 void NCCLCommunicator::stop()
 {
-    NCCL_CALL( ncclGroupEnd() );
+  NCCL_CALL(ncclGroupEnd());
 
-    for (std::size_t ibuffer = 0; ibuffer < recv_buffers.size(); ibuffer++) {
-        std::size_t idx = recv_buffer_idx[ibuffer];
-        CUDA_RT_CALL(cudaMemcpyAsync(
-            recv_buffers[ibuffer], comm_buffers[idx], comm_buffer_sizes[idx],
-            cudaMemcpyDeviceToDevice, comm_stream
-        ));
-    }
+  for (std::size_t ibuffer = 0; ibuffer < recv_buffers.size(); ibuffer++) {
+    std::size_t idx = recv_buffer_idx[ibuffer];
+    CUDA_RT_CALL(cudaMemcpyAsync(recv_buffers[ibuffer],
+                                 comm_buffers[idx],
+                                 comm_buffer_sizes[idx],
+                                 cudaMemcpyDeviceToDevice,
+                                 comm_stream));
+  }
 
-    for (std::size_t ibuffer = 0; ibuffer < comm_buffers.size(); ibuffer++) {
-        std::size_t aligned_size = (comm_buffer_sizes[ibuffer] + 255) / 256 * 256;
-        rmm::mr::get_current_device_resource()->deallocate(
-            comm_buffers[ibuffer], aligned_size, comm_stream);
-    }
+  for (std::size_t ibuffer = 0; ibuffer < comm_buffers.size(); ibuffer++) {
+    std::size_t aligned_size = (comm_buffer_sizes[ibuffer] + 255) / 256 * 256;
+    rmm::mr::get_current_device_resource()->deallocate(
+      comm_buffers[ibuffer], aligned_size, comm_stream);
+  }
 
-    CUDA_RT_CALL( cudaStreamSynchronize(comm_stream) );
+  CUDA_RT_CALL(cudaStreamSynchronize(comm_stream));
 }
-
 
 void NCCLCommunicator::finalize()
 {
-    CUDA_RT_CALL( cudaStreamDestroy(comm_stream) );
-    NCCL_CALL( ncclCommDestroy(nccl_comm) );
+  CUDA_RT_CALL(cudaStreamDestroy(comm_stream));
+  NCCL_CALL(ncclCommDestroy(nccl_comm));
 }

--- a/src/error.cuh
+++ b/src/error.cuh
@@ -20,70 +20,83 @@
 #include <cstdio>
 #include <cstdlib>
 
-
 #ifndef CUDA_RT_CALL
-#define CUDA_RT_CALL(call)                                                                         \
-{                                                                                                  \
-    cudaError_t cudaStatus = call;                                                                 \
-    if (cudaSuccess != cudaStatus) {                                                               \
-        fprintf(stderr, "ERROR: CUDA RT call \"%s\" in line %d of file %s failed with %s (%d).\n", \
-                        #call, __LINE__, __FILE__, cudaGetErrorString(cudaStatus), cudaStatus);    \
-        exit(1);                                                                                   \
-    }                                                                                              \
-}
+#define CUDA_RT_CALL(call)                                                               \
+  {                                                                                      \
+    cudaError_t cudaStatus = call;                                                       \
+    if (cudaSuccess != cudaStatus) {                                                     \
+      fprintf(stderr,                                                                    \
+              "ERROR: CUDA RT call \"%s\" in line %d of file %s failed with %s (%d).\n", \
+              #call,                                                                     \
+              __LINE__,                                                                  \
+              __FILE__,                                                                  \
+              cudaGetErrorString(cudaStatus),                                            \
+              cudaStatus);                                                               \
+      exit(1);                                                                           \
+    }                                                                                    \
+  }
 #endif
-
 
 #ifndef UCX_CALL
-#define UCX_CALL(call)                                                                             \
-{                                                                                                  \
-    ucs_status_t status = call;                                                                    \
-    if (UCS_OK != status) {                                                                        \
-        fprintf(stderr, "\"%s\" in line %d of file %s failed with %s (%d).\n",                     \
-                        #call, __LINE__, __FILE__, ucs_status_string(status), status);             \
-        exit(1);                                                                                   \
-    }                                                                                              \
-}
+#define UCX_CALL(call)                                               \
+  {                                                                  \
+    ucs_status_t status = call;                                      \
+    if (UCS_OK != status) {                                          \
+      fprintf(stderr,                                                \
+              "\"%s\" in line %d of file %s failed with %s (%d).\n", \
+              #call,                                                 \
+              __LINE__,                                              \
+              __FILE__,                                              \
+              ucs_status_string(status),                             \
+              status);                                               \
+      exit(1);                                                       \
+    }                                                                \
+  }
 #endif
-
 
 #ifndef MPI_CALL
-#define MPI_CALL(call)                                                                             \
-{                                                                                                  \
-    int status = call;                                                                             \
-    if (MPI_SUCCESS != status) {                                                                   \
-        int len;                                                                                   \
-        char estring[MPI_MAX_ERROR_STRING];                                                        \
-        MPI_Error_string(status, estring, &len);                                                   \
-        fprintf(stderr, "\"%s\" in line %d of file %s failed with %s (%d).\n",                     \
-                #call, __LINE__, __FILE__, estring, status);                                       \
-        exit(1);                                                                                   \
-    }                                                                                              \
-}
+#define MPI_CALL(call)                                               \
+  {                                                                  \
+    int status = call;                                               \
+    if (MPI_SUCCESS != status) {                                     \
+      int len;                                                       \
+      char estring[MPI_MAX_ERROR_STRING];                            \
+      MPI_Error_string(status, estring, &len);                       \
+      fprintf(stderr,                                                \
+              "\"%s\" in line %d of file %s failed with %s (%d).\n", \
+              #call,                                                 \
+              __LINE__,                                              \
+              __FILE__,                                              \
+              estring,                                               \
+              status);                                               \
+      exit(1);                                                       \
+    }                                                                \
+  }
 #endif
-
 
 #ifndef NCCL_CALL
-#define NCCL_CALL(call)                                                                            \
-{                                                                                                  \
-    ncclResult_t status = call;                                                                    \
-    if (ncclSuccess != status) {                                                                   \
-        fprintf(stderr, "ERROR: nccl call \"%s\" in line %d of file %s failed with %s.\n",         \
-                        #call, __LINE__, __FILE__, ncclGetErrorString(status));                    \
-        exit(1);                                                                                   \
-    }                                                                                              \
-}
+#define NCCL_CALL(call)                                                          \
+  {                                                                              \
+    ncclResult_t status = call;                                                  \
+    if (ncclSuccess != status) {                                                 \
+      fprintf(stderr,                                                            \
+              "ERROR: nccl call \"%s\" in line %d of file %s failed with %s.\n", \
+              #call,                                                             \
+              __LINE__,                                                          \
+              __FILE__,                                                          \
+              ncclGetErrorString(status));                                       \
+      exit(1);                                                                   \
+    }                                                                            \
+  }
 #endif
 
+#define CHECK_ERROR(rtv, expected_value, msg)                                        \
+  {                                                                                  \
+    if (rtv != expected_value) {                                                     \
+      fprintf(stderr, "ERROR on line %d of file %s: %s\n", __LINE__, __FILE__, msg); \
+      std::cerr << rtv << std::endl;                                                 \
+      exit(1);                                                                       \
+    }                                                                                \
+  }
 
-#define CHECK_ERROR(rtv, expected_value, msg)                                            \
-{                                                                                        \
-    if (rtv != expected_value) {                                                         \
-        fprintf(stderr, "ERROR on line %d of file %s: %s\n",  __LINE__, __FILE__, msg);  \
-        std::cerr << rtv << std::endl;                                                   \
-        exit(1);                                                                         \
-    }                                                                                    \
-}
-
-
-#endif // __ERROR_CUH
+#endif  // __ERROR_CUH

--- a/src/generate_table.cuh
+++ b/src/generate_table.cuh
@@ -17,117 +17,104 @@
 #ifndef __GENERATE_TABLE_CUH
 #define __GENERATE_TABLE_CUH
 
-#include <vector>
-#include <utility>
 #include <memory>
 #include <stdexcept>
 #include <tuple>
+#include <utility>
+#include <vector>
 
-#include <cudf/types.hpp>
-#include <cudf/table/table.hpp>
+#include <thrust/execution_policy.h>
+#include <thrust/sequence.h>
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
-#include <thrust/sequence.h>
-#include <thrust/execution_policy.h>
 
-#include "error.cuh"
 #include "../generate_dataset/generate_dataset.cuh"
 #include "distributed_join.cuh"
+#include "error.cuh"
 
 using cudf::table;
 
-
 /**
-* Generate a build table and a probe table for testing distributed join.
-*
-* Both the build table and the probe table have two columns. The first column is the key column,
-* with datatype KEY_T. The second column is the payload column, with datatype PAYLOAD_T.
-*
-* @param[in] build_table_nrows The number of rows in the build table.
-* @param[in] probe_table_nrows The number of rows in the probe table.
-* @param[in] selectivity Propability with which an element of the probe table is present in the
-* build table.
-* @param[in] rand_max Maximum random number to generate, i.e., random numbers are integers from
-* [0, rand_max].
-* @param[in] uniq_build_tbl_keys If each key in the build table should appear exactly once.
-*
-* @return A pair of generated build table and probe table.
-*/
-template<typename KEY_T, typename PAYLOAD_T>
-std::pair<std::unique_ptr<table>, std::unique_ptr<table> >
-generate_build_probe_tables(cudf::size_type build_table_nrows,
-                            cudf::size_type probe_table_nrows,
-                            double selectivity,
-                            KEY_T rand_max,
-                            bool uniq_build_tbl_keys)
+ * Generate a build table and a probe table for testing distributed join.
+ *
+ * Both the build table and the probe table have two columns. The first column is the key column,
+ * with datatype KEY_T. The second column is the payload column, with datatype PAYLOAD_T.
+ *
+ * @param[in] build_table_nrows The number of rows in the build table.
+ * @param[in] probe_table_nrows The number of rows in the probe table.
+ * @param[in] selectivity Propability with which an element of the probe table is present in the
+ * build table.
+ * @param[in] rand_max Maximum random number to generate, i.e., random numbers are integers from
+ * [0, rand_max].
+ * @param[in] uniq_build_tbl_keys If each key in the build table should appear exactly once.
+ *
+ * @return A pair of generated build table and probe table.
+ */
+template <typename KEY_T, typename PAYLOAD_T>
+std::pair<std::unique_ptr<table>, std::unique_ptr<table>> generate_build_probe_tables(
+  cudf::size_type build_table_nrows,
+  cudf::size_type probe_table_nrows,
+  double selectivity,
+  KEY_T rand_max,
+  bool uniq_build_tbl_keys)
 {
-    // Allocate device memory for the generated columns
+  // Allocate device memory for the generated columns
 
-    std::vector<std::unique_ptr<cudf::column> > build;
-    std::vector<std::unique_ptr<cudf::column> > probe;
+  std::vector<std::unique_ptr<cudf::column>> build;
+  std::vector<std::unique_ptr<cudf::column>> probe;
 
-    constexpr cudf::data_type key_type = cudf::data_type(
-        cudf::type_to_id<KEY_T>()
-    );
+  constexpr cudf::data_type key_type = cudf::data_type(cudf::type_to_id<KEY_T>());
 
-    constexpr cudf::data_type payload_type = cudf::data_type(
-        cudf::type_to_id<PAYLOAD_T>()
-    );
+  constexpr cudf::data_type payload_type = cudf::data_type(cudf::type_to_id<PAYLOAD_T>());
 
-    build.push_back(std::move(
-        cudf::make_numeric_column(key_type, build_table_nrows)
-    ));
+  build.push_back(std::move(cudf::make_numeric_column(key_type, build_table_nrows)));
 
-    build.push_back(std::move(
-        cudf::make_numeric_column(payload_type, build_table_nrows)
-    ));
+  build.push_back(std::move(cudf::make_numeric_column(payload_type, build_table_nrows)));
 
-    probe.push_back(std::move(
-        cudf::make_numeric_column(key_type, probe_table_nrows)
-    ));
+  probe.push_back(std::move(cudf::make_numeric_column(key_type, probe_table_nrows)));
 
-    probe.push_back(std::move(
-        cudf::make_numeric_column(payload_type, probe_table_nrows)
-    ));
+  probe.push_back(std::move(cudf::make_numeric_column(payload_type, probe_table_nrows)));
 
-    // Generate build and probe table data
+  // Generate build and probe table data
 
-    generate_input_tables<KEY_T, cudf::size_type>(
-        build[0]->mutable_view().head<KEY_T>(), build_table_nrows,
-        probe[0]->mutable_view().head<KEY_T>(), probe_table_nrows,
-        selectivity, rand_max, uniq_build_tbl_keys
-    );
+  generate_input_tables<KEY_T, cudf::size_type>(build[0]->mutable_view().head<KEY_T>(),
+                                                build_table_nrows,
+                                                probe[0]->mutable_view().head<KEY_T>(),
+                                                probe_table_nrows,
+                                                selectivity,
+                                                rand_max,
+                                                uniq_build_tbl_keys);
 
-    auto build_payload_ptr = build[1]->mutable_view().head<PAYLOAD_T>();
-    thrust::sequence(thrust::device, build_payload_ptr, build_payload_ptr + build_table_nrows);
+  auto build_payload_ptr = build[1]->mutable_view().head<PAYLOAD_T>();
+  thrust::sequence(thrust::device, build_payload_ptr, build_payload_ptr + build_table_nrows);
 
-    auto probe_payload_ptr = probe[1]->mutable_view().head<PAYLOAD_T>();
-    thrust::sequence(thrust::device, probe_payload_ptr, probe_payload_ptr + probe_table_nrows);
+  auto probe_payload_ptr = probe[1]->mutable_view().head<PAYLOAD_T>();
+  thrust::sequence(thrust::device, probe_payload_ptr, probe_payload_ptr + probe_table_nrows);
 
-    CUDA_RT_CALL(cudaGetLastError());
-    CUDA_RT_CALL(cudaDeviceSynchronize());
+  CUDA_RT_CALL(cudaGetLastError());
+  CUDA_RT_CALL(cudaDeviceSynchronize());
 
-    // return the generated tables
+  // return the generated tables
 
-    auto build_table = std::make_unique<table>(std::move(build));
-    auto probe_table = std::make_unique<table>(std::move(probe));
+  auto build_table = std::make_unique<table>(std::move(build));
+  auto probe_table = std::make_unique<table>(std::move(probe));
 
-    return std::make_pair(std::move(build_table), std::move(probe_table));
+  return std::make_pair(std::move(build_table), std::move(probe_table));
 }
-
 
 template <typename data_type>
 void add_constant_to_column(cudf::mutable_column_view column, data_type constant)
 {
-    auto buffer_ptr = thrust::device_pointer_cast(column.head<data_type>());
+  auto buffer_ptr = thrust::device_pointer_cast(column.head<data_type>());
 
-    thrust::transform(buffer_ptr, buffer_ptr + column.size(), buffer_ptr,
-                      [=] __device__ (data_type &i) {
-                          return i + constant;
-                      });
+  thrust::transform(
+    buffer_ptr, buffer_ptr + column.size(), buffer_ptr, [=] __device__(data_type & i) {
+      return i + constant;
+    });
 }
-
 
 /**
  * This function generates build table and probe table distributed, and it need to be called
@@ -135,125 +122,119 @@ void add_constant_to_column(cudf::mutable_column_view column, data_type constant
  *
  * @param[in] build_table_nrows_per_rank   The number of rows of build table on each rank.
  * @param[in] probe_table_nrows_per_rank   The number of rows of probe table on each rank.
- * @param[in] selectivity                  The percentage of keys in the probe table present in the build table.
- * @param[in] rand_max_per_rank            The lottery size on each rank. This argument should be set larger than
- *                                         `build_table_size_per_rank`.
+ * @param[in] selectivity                  The percentage of keys in the probe table present in the
+ * build table.
+ * @param[in] rand_max_per_rank            The lottery size on each rank. This argument should be
+ * set larger than `build_table_size_per_rank`.
  * @param[in] uniq_build_tbl_keys          Whether the keys in the build table are unique.
  * @param[in] communicator                 An instance of `Communicator` used for communication.
  *
- * Note: require build_table_size_per_rank % mpi_rank == 0 and probe_table_size_per_rank % mpi_rank == 0.
+ * Note: require build_table_size_per_rank % mpi_rank == 0 and probe_table_size_per_rank % mpi_rank
+ * == 0.
  *
  * @return A pair of generated build and probe table distributed on each rank.
  */
-template<typename KEY_T, typename PAYLOAD_T>
-std::pair<std::unique_ptr<table>, std::unique_ptr<table> >
-generate_tables_distributed(
-    cudf::size_type build_table_nrows_per_rank,
-    cudf::size_type probe_table_nrows_per_rank,
-    double selectivity,
-    KEY_T rand_max_per_rank,
-    bool uniq_build_tbl_keys,
-    Communicator *communicator)
+template <typename KEY_T, typename PAYLOAD_T>
+std::pair<std::unique_ptr<table>, std::unique_ptr<table>> generate_tables_distributed(
+  cudf::size_type build_table_nrows_per_rank,
+  cudf::size_type probe_table_nrows_per_rank,
+  double selectivity,
+  KEY_T rand_max_per_rank,
+  bool uniq_build_tbl_keys,
+  Communicator *communicator)
 {
-    // Algorithm used for distributed generation:
-    // Rank i generates build and probe table independently with keys randomly selected from range
-    // [i*uniq_build_tbl_keys, (i+1)*uniq_build_tbl_keys] (called pre_shuffle_table). Afterwards,
-    // pre_shuffle_table will be divided into N chunks with the same number of rows, and then send
-    // chunk j to rank j. This all-to-all communication will make each local table have keys
-    // uniformly from the whole range.
+  // Algorithm used for distributed generation:
+  // Rank i generates build and probe table independently with keys randomly selected from range
+  // [i*uniq_build_tbl_keys, (i+1)*uniq_build_tbl_keys] (called pre_shuffle_table). Afterwards,
+  // pre_shuffle_table will be divided into N chunks with the same number of rows, and then send
+  // chunk j to rank j. This all-to-all communication will make each local table have keys
+  // uniformly from the whole range.
 
-    // Get MPI information
+  // Get MPI information
 
-    int mpi_rank, mpi_size;
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+  int mpi_rank, mpi_size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
-    // Generate local build and probe table on each rank
+  // Generate local build and probe table on each rank
 
-    std::unique_ptr<table> pre_shuffle_build_table;
-    std::unique_ptr<table> pre_shuffle_probe_table;
+  std::unique_ptr<table> pre_shuffle_build_table;
+  std::unique_ptr<table> pre_shuffle_probe_table;
 
-    std::tie(pre_shuffle_build_table, pre_shuffle_probe_table) = \
-        generate_build_probe_tables<KEY_T, PAYLOAD_T>(
-            build_table_nrows_per_rank, probe_table_nrows_per_rank,
-            selectivity, rand_max_per_rank, uniq_build_tbl_keys
-        );
+  std::tie(pre_shuffle_build_table, pre_shuffle_probe_table) =
+    generate_build_probe_tables<KEY_T, PAYLOAD_T>(build_table_nrows_per_rank,
+                                                  probe_table_nrows_per_rank,
+                                                  selectivity,
+                                                  rand_max_per_rank,
+                                                  uniq_build_tbl_keys);
 
-    // Add constant to build and probe table to make sure the range is correct
+  // Add constant to build and probe table to make sure the range is correct
 
-    add_constant_to_column<KEY_T>(
-        pre_shuffle_build_table->mutable_view().column(0), rand_max_per_rank * mpi_rank
-    );
+  add_constant_to_column<KEY_T>(pre_shuffle_build_table->mutable_view().column(0),
+                                rand_max_per_rank * mpi_rank);
 
-    add_constant_to_column<KEY_T>(
-        pre_shuffle_probe_table->mutable_view().column(0), rand_max_per_rank * mpi_rank
-    );
+  add_constant_to_column<KEY_T>(pre_shuffle_probe_table->mutable_view().column(0),
+                                rand_max_per_rank * mpi_rank);
 
-    add_constant_to_column<PAYLOAD_T>(
-        pre_shuffle_build_table->mutable_view().column(1), build_table_nrows_per_rank * mpi_rank
-    );
+  add_constant_to_column<PAYLOAD_T>(pre_shuffle_build_table->mutable_view().column(1),
+                                    build_table_nrows_per_rank * mpi_rank);
 
-    add_constant_to_column<PAYLOAD_T>(
-        pre_shuffle_probe_table->mutable_view().column(1), probe_table_nrows_per_rank * mpi_rank
-    );
+  add_constant_to_column<PAYLOAD_T>(pre_shuffle_probe_table->mutable_view().column(1),
+                                    probe_table_nrows_per_rank * mpi_rank);
 
-    // Construct buffer offset to indicate the start indices to each rank
+  // Construct buffer offset to indicate the start indices to each rank
 
-    std::vector<cudf::size_type> build_table_offset(mpi_size + 1);
-    std::vector<cudf::size_type> probe_table_offset(mpi_size + 1);
+  std::vector<cudf::size_type> build_table_offset(mpi_size + 1);
+  std::vector<cudf::size_type> probe_table_offset(mpi_size + 1);
 
-    for (cudf::size_type irank = 0; irank <= mpi_size; irank ++) {
-        build_table_offset[irank] = build_table_nrows_per_rank / mpi_size * irank;
-        probe_table_offset[irank] = probe_table_nrows_per_rank / mpi_size * irank;
-    }
+  for (cudf::size_type irank = 0; irank <= mpi_size; irank++) {
+    build_table_offset[irank] = build_table_nrows_per_rank / mpi_size * irank;
+    probe_table_offset[irank] = probe_table_nrows_per_rank / mpi_size * irank;
+  }
 
-    // Allocate memory for the result tables
+  // Allocate memory for the result tables
 
-    vector<int64_t> build_table_recv_offset;
-    vector<int64_t> probe_table_recv_offset;
+  vector<int64_t> build_table_recv_offset;
+  vector<int64_t> probe_table_recv_offset;
 
-    communicate_sizes(build_table_offset, build_table_recv_offset, communicator);
-    communicate_sizes(probe_table_offset, probe_table_recv_offset, communicator);
+  communicate_sizes(build_table_offset, build_table_recv_offset, communicator);
+  communicate_sizes(probe_table_offset, probe_table_recv_offset, communicator);
 
-    vector<std::unique_ptr<column> > build_table_columns;
-    for (cudf::size_type icol = 0; icol < pre_shuffle_build_table->num_columns(); icol++) {
-        build_table_columns.push_back(make_numeric_column(
-            pre_shuffle_build_table->view().column(icol).type(),
-            build_table_recv_offset.back()
-        ));
-    }
-    std::unique_ptr<table> build_table = std::make_unique<table>(std::move(build_table_columns));
+  vector<std::unique_ptr<column>> build_table_columns;
+  for (cudf::size_type icol = 0; icol < pre_shuffle_build_table->num_columns(); icol++) {
+    build_table_columns.push_back(make_numeric_column(
+      pre_shuffle_build_table->view().column(icol).type(), build_table_recv_offset.back()));
+  }
+  std::unique_ptr<table> build_table = std::make_unique<table>(std::move(build_table_columns));
 
-    vector<std::unique_ptr<column> > probe_table_columns;
-    for (cudf::size_type icol = 0; icol < pre_shuffle_probe_table->num_columns(); icol++) {
-        probe_table_columns.push_back(make_numeric_column(
-            pre_shuffle_probe_table->view().column(icol).type(),
-            probe_table_recv_offset.back()
-        ));
-    }
-    std::unique_ptr<table> probe_table = std::make_unique<table>(std::move(probe_table_columns));
+  vector<std::unique_ptr<column>> probe_table_columns;
+  for (cudf::size_type icol = 0; icol < pre_shuffle_probe_table->num_columns(); icol++) {
+    probe_table_columns.push_back(make_numeric_column(
+      pre_shuffle_probe_table->view().column(icol).type(), probe_table_recv_offset.back()));
+  }
+  std::unique_ptr<table> probe_table = std::make_unique<table>(std::move(probe_table_columns));
 
-    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
+  CUDA_RT_CALL(cudaStreamSynchronize(cudaStreamDefault));
 
-    // Send each bucket to the desired target rank
+  // Send each bucket to the desired target rank
 
-    if (communicator->group_by_batch())
-        communicator->start();
+  if (communicator->group_by_batch()) communicator->start();
 
-    all_to_all_comm(
-        pre_shuffle_build_table->view(), build_table->mutable_view(),
-        build_table_offset, build_table_recv_offset, communicator
-    );
+  all_to_all_comm(pre_shuffle_build_table->view(),
+                  build_table->mutable_view(),
+                  build_table_offset,
+                  build_table_recv_offset,
+                  communicator);
 
-    all_to_all_comm(
-        pre_shuffle_probe_table->view(), probe_table->mutable_view(),
-        probe_table_offset, probe_table_recv_offset, communicator
-    );
+  all_to_all_comm(pre_shuffle_probe_table->view(),
+                  probe_table->mutable_view(),
+                  probe_table_offset,
+                  probe_table_recv_offset,
+                  communicator);
 
-    if (communicator->group_by_batch())
-        communicator->stop();
+  if (communicator->group_by_batch()) communicator->stop();
 
-    return std::make_pair(std::move(build_table), std::move(probe_table));
+  return std::make_pair(std::move(build_table), std::move(probe_table));
 }
 
-#endif // __GENERATE_TABLE_CUH
+#endif  // __GENERATE_TABLE_CUH

--- a/src/registered_memory_resource.hpp
+++ b/src/registered_memory_resource.hpp
@@ -19,9 +19,9 @@
 #pragma once
 
 #include <map>
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 #include "communicator.h"
 
 /**
@@ -30,12 +30,9 @@
  */
 class registered_memory_resource final : public rmm::mr::device_memory_resource {
  public:
-  registered_memory_resource(UCXCommunicator *communicator)
-  {
-    this->communicator = communicator;
-  }
+  registered_memory_resource(UCXCommunicator* communicator) { this->communicator = communicator; }
 
-  ~registered_memory_resource()                           = default;
+  ~registered_memory_resource()                                 = default;
   registered_memory_resource(registered_memory_resource const&) = default;
   registered_memory_resource(registered_memory_resource&&)      = default;
   registered_memory_resource& operator=(registered_memory_resource const&) = default;
@@ -127,6 +124,6 @@ class registered_memory_resource final : public rmm::mr::device_memory_resource 
     return std::make_pair(free_size, total_size);
   }
 
-  UCXCommunicator *communicator;
-  std::map<void *, ucp_mem_h> registered_handles;
+  UCXCommunicator* communicator;
+  std::map<void*, ucp_mem_h> registered_handles;
 };

--- a/src/registered_memory_resource.hpp
+++ b/src/registered_memory_resource.hpp
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include "communicator.h"
 
@@ -68,7 +69,7 @@ class registered_memory_resource final : public rmm::mr::device_memory_resource 
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cudaStream_t) override
+  void* do_allocate(std::size_t bytes, rmm::cuda_stream_view) override
   {
     void* p{nullptr};
     RMM_CUDA_TRY(cudaMalloc(&p, bytes), rmm::bad_alloc);
@@ -87,7 +88,7 @@ class registered_memory_resource final : public rmm::mr::device_memory_resource 
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, cudaStream_t) override
+  void do_deallocate(void* p, std::size_t, rmm::cuda_stream_view) override
   {
     ucp_mem_h memory_handle = registered_handles.find(p)->second;
     communicator->deregister_buffer(memory_handle);
@@ -118,7 +119,7 @@ class registered_memory_resource final : public rmm::mr::device_memory_resource 
    *
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t) const override
+  std::pair<size_t, size_t> do_get_mem_info(rmm::cuda_stream_view) const override
   {
     std::size_t free_size;
     std::size_t total_size;

--- a/src/topology.cuh
+++ b/src/topology.cuh
@@ -14,26 +14,25 @@
  * limitations under the License.
  */
 
-#include <iostream>
 #include <mpi.h>
+#include <iostream>
 
 #include "error.cuh"
 
-
 void setup_topology(int argc, char *argv[])
 {
-    int device_count;
-    int mpi_rank;
+  int device_count;
+  int mpi_rank;
 
-    MPI_CALL( MPI_Init(&argc, &argv) );
-    MPI_CALL( MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank) );
+  MPI_CALL(MPI_Init(&argc, &argv));
+  MPI_CALL(MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank));
 
-    CUDA_RT_CALL( cudaGetDeviceCount(&device_count) );
-    std::cout << "Device count: " << device_count << std::endl;
+  CUDA_RT_CALL(cudaGetDeviceCount(&device_count));
+  std::cout << "Device count: " << device_count << std::endl;
 
-    int current_device = mpi_rank % device_count;
+  int current_device = mpi_rank % device_count;
 
-    CUDA_RT_CALL( cudaSetDevice(current_device) );
-    std::cout << "Rank " << mpi_rank << " select " << current_device << "/" << device_count << " GPU"
-              << std::endl;
+  CUDA_RT_CALL(cudaSetDevice(current_device));
+  std::cout << "Rank " << mpi_rank << " select " << current_device << "/" << device_count << " GPU"
+            << std::endl;
 }

--- a/test/buffer_communicator.cu
+++ b/test/buffer_communicator.cu
@@ -14,148 +14,134 @@
  * limitations under the License.
  */
 
-#include <cstdint>
-#include <vector>
-#include <iostream>
-#include <cassert>
 #include <mpi.h>
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <vector>
 
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
-#include "../src/topology.cuh"
 #include "../src/communicator.h"
 #include "../src/error.cuh"
+#include "../src/topology.cuh"
 
 static int64_t COUNT = 50'000'000LL;
 
-
 void parse_command_line_arguments(int argc, char *argv[])
 {
-    for (int iarg = 0; iarg < argc; iarg++) {
-        if (!strcmp(argv[iarg], "--count")) {
-            COUNT = atol(argv[iarg + 1]);
-        }
-    }
+  for (int iarg = 0; iarg < argc; iarg++) {
+    if (!strcmp(argv[iarg], "--count")) { COUNT = atol(argv[iarg + 1]); }
+  }
 }
-
 
 __global__ void set_data(uint64_t *start_addr, uint64_t size, uint64_t start_val)
 {
-    const int ithread = threadIdx.x + blockDim.x * blockIdx.x;
-    const int stride = blockDim.x * gridDim.x;
+  const int ithread = threadIdx.x + blockDim.x * blockIdx.x;
+  const int stride  = blockDim.x * gridDim.x;
 
-    for (uint64_t ielement = ithread; ielement < size; ielement += stride) {
-        start_addr[ielement] = (start_val + ielement);
-    }
+  for (uint64_t ielement = ithread; ielement < size; ielement += stride) {
+    start_addr[ielement] = (start_val + ielement);
+  }
 }
-
 
 __global__ void test_correctness(uint64_t *start_addr, uint64_t size, uint64_t start_val)
 {
-    const int ithread = threadIdx.x + blockDim.x * blockIdx.x;
-    const int stride = blockDim.x * gridDim.x;
+  const int ithread = threadIdx.x + blockDim.x * blockIdx.x;
+  const int stride  = blockDim.x * gridDim.x;
 
-    for (uint64_t ielement = ithread; ielement < size; ielement += stride) {
-        assert(start_addr[ielement] == (start_val + ielement));
-    }
+  for (uint64_t ielement = ithread; ielement < size; ielement += stride) {
+    assert(start_addr[ielement] == (start_val + ielement));
+  }
 }
-
 
 int main(int argc, char *argv[])
 {
-    /* Initialize topology */
+  /* Initialize topology */
 
-    setup_topology(argc, argv);
+  setup_topology(argc, argv);
 
-    /* Parse command line arguments */
+  /* Parse command line arguments */
 
-    parse_command_line_arguments(argc, argv);
+  parse_command_line_arguments(argc, argv);
 
-    /* Initialize memory pool */
+  /* Initialize memory pool */
 
-    size_t free_memory, total_memory;
-    CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
-    const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
+  size_t free_memory, total_memory;
+  CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
+  const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
 
-    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource();
-    rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr {mr, pool_size, pool_size};
-    rmm::mr::set_current_device_resource(&pool_mr);
+  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource();
+  rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr{mr, pool_size, pool_size};
+  rmm::mr::set_current_device_resource(&pool_mr);
 
-    /* Initialize communicator */
+  /* Initialize communicator */
 
-    int mpi_rank;
-    int mpi_size;
-    MPI_CALL( MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank) );
-    MPI_CALL( MPI_Comm_size(MPI_COMM_WORLD, &mpi_size) );
+  int mpi_rank;
+  int mpi_size;
+  MPI_CALL(MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank));
+  MPI_CALL(MPI_Comm_size(MPI_COMM_WORLD, &mpi_size));
 
-    UCXCommunicator* communicator = initialize_ucx_communicator(
-        true, 2 * mpi_size, 20'000'000LL
-    );
+  UCXCommunicator *communicator = initialize_ucx_communicator(true, 2 * mpi_size, 20'000'000LL);
 
-    /* Send and recv data */
+  /* Send and recv data */
 
-    rmm::device_buffer send_buf {COUNT * sizeof(uint64_t), 0};
-    std::vector<uint64_t *> recv_buf(mpi_size, nullptr);
+  rmm::device_buffer send_buf{COUNT * sizeof(uint64_t), 0};
+  std::vector<uint64_t *> recv_buf(mpi_size, nullptr);
 
-    std::vector<comm_handle_t> send_reqs(mpi_size, nullptr);
-    std::vector<comm_handle_t> recv_reqs(mpi_size, nullptr);
+  std::vector<comm_handle_t> send_reqs(mpi_size, nullptr);
+  std::vector<comm_handle_t> recv_reqs(mpi_size, nullptr);
 
-    int grid_size {-1};
-    int block_size {-1};
+  int grid_size{-1};
+  int block_size{-1};
 
-    CUDA_RT_CALL(cudaOccupancyMaxPotentialBlockSize(&grid_size, &block_size, set_data));
-    set_data<<<grid_size, block_size>>>(
-        static_cast<uint64_t *>(send_buf.data()), COUNT, COUNT * mpi_rank
-    );
+  CUDA_RT_CALL(cudaOccupancyMaxPotentialBlockSize(&grid_size, &block_size, set_data));
+  set_data<<<grid_size, block_size>>>(
+    static_cast<uint64_t *>(send_buf.data()), COUNT, COUNT * mpi_rank);
 
-    for (int irank = 0; irank < mpi_size; irank ++) {
-        if (irank != mpi_rank) {
-            send_reqs[irank] = communicator->send(send_buf.data(), COUNT, sizeof(uint64_t), irank, 32);
-        }
+  for (int irank = 0; irank < mpi_size; irank++) {
+    if (irank != mpi_rank) {
+      send_reqs[irank] = communicator->send(send_buf.data(), COUNT, sizeof(uint64_t), irank, 32);
     }
+  }
 
-    int64_t count_received;
+  int64_t count_received;
 
-    for (int irank = mpi_size - 1; irank >= 0; irank --) {
-        if (irank != mpi_rank) {
-            recv_reqs[irank] = communicator->recv(
-                (void **)&recv_buf[irank], &count_received, sizeof(uint64_t), irank, 32
-            );
-        }
+  for (int irank = mpi_size - 1; irank >= 0; irank--) {
+    if (irank != mpi_rank) {
+      recv_reqs[irank] =
+        communicator->recv((void **)&recv_buf[irank], &count_received, sizeof(uint64_t), irank, 32);
     }
+  }
 
-    communicator->waitall(send_reqs);
-    communicator->waitall(recv_reqs);
+  communicator->waitall(send_reqs);
+  communicator->waitall(recv_reqs);
 
-    assert(count_received == COUNT);
+  assert(count_received == COUNT);
 
-    /* Test the correctness */
+  /* Test the correctness */
 
-    for (int irank = 0; irank < mpi_size; irank ++) {
-        if (irank != mpi_rank) {
-            test_correctness<<<grid_size, block_size>>>(recv_buf[irank], COUNT, COUNT * irank);
-        }
+  for (int irank = 0; irank < mpi_size; irank++) {
+    if (irank != mpi_rank) {
+      test_correctness<<<grid_size, block_size>>>(recv_buf[irank], COUNT, COUNT * irank);
     }
+  }
 
-    /* Cleanup */
+  /* Cleanup */
 
-    for (int irank = 0; irank < mpi_size; irank ++) {
-        if (irank != mpi_rank) {
-            rmm::mr::get_current_device_resource()->deallocate(
-                recv_buf[irank], COUNT, cudaStreamDefault
-            );
-        }
+  for (int irank = 0; irank < mpi_size; irank++) {
+    if (irank != mpi_rank) {
+      rmm::mr::get_current_device_resource()->deallocate(recv_buf[irank], COUNT, cudaStreamDefault);
     }
+  }
 
-    CUDA_RT_CALL( cudaStreamSynchronize(cudaStreamDefault) );
-    communicator->finalize();
-    delete communicator;
+  CUDA_RT_CALL(cudaStreamSynchronize(cudaStreamDefault));
+  communicator->finalize();
+  delete communicator;
 
-    if (mpi_rank == 0) {
-        std::cerr << "Test case \"buffer_communicator\" passes successfully.\n";
-    }
+  if (mpi_rank == 0) { std::cerr << "Test case \"buffer_communicator\" passes successfully.\n"; }
 
-    return 0;
+  return 0;
 }

--- a/test/compare_against_shared.cu
+++ b/test/compare_against_shared.cu
@@ -15,25 +15,25 @@
  */
 
 #include <iostream>
-#include <vector>
 #include <memory>
-#include <utility>
 #include <tuple>
+#include <utility>
+#include <vector>
 
-#include <cudf/table/table.hpp>
 #include <cudf/join.hpp>
 #include <cudf/sorting.hpp>
+#include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
-#include "../src/topology.cuh"
 #include "../src/communicator.h"
-#include "../src/error.cuh"
-#include "../src/generate_table.cuh"
 #include "../src/distribute_table.cuh"
 #include "../src/distributed_join.cuh"
+#include "../src/error.cuh"
+#include "../src/generate_table.cuh"
 #include "../src/registered_memory_resource.hpp"
+#include "../src/topology.cuh"
 
 using cudf::table;
 
@@ -42,188 +42,169 @@ using cudf::table;
 
 static cudf::size_type BUILD_TABLE_SIZE = 1'000'000;
 static cudf::size_type PROBE_TABLE_SIZE = 5'000'000;
-static double SELECTIVITY = 0.3;
-static bool IS_BUILD_TABLE_KEY_UNIQUE = true;
-static int OVER_DECOMPOSITION_FACTOR = 10;
-
+static double SELECTIVITY               = 0.3;
+static bool IS_BUILD_TABLE_KEY_UNIQUE   = true;
+static int OVER_DECOMPOSITION_FACTOR    = 10;
 
 void parse_command_line_arguments(int argc, char *argv[])
 {
-    for (int iarg = 0; iarg < argc; iarg++) {
-        if (!strcmp(argv[iarg], "--build-table-nrows")) {
-            BUILD_TABLE_SIZE = atoi(argv[iarg + 1]);
-        }
+  for (int iarg = 0; iarg < argc; iarg++) {
+    if (!strcmp(argv[iarg], "--build-table-nrows")) { BUILD_TABLE_SIZE = atoi(argv[iarg + 1]); }
 
-        if (!strcmp(argv[iarg], "--probe-table-nrows")) {
-            PROBE_TABLE_SIZE = atoi(argv[iarg + 1]);
-        }
+    if (!strcmp(argv[iarg], "--probe-table-nrows")) { PROBE_TABLE_SIZE = atoi(argv[iarg + 1]); }
 
-        if (!strcmp(argv[iarg], "--selectivity")) {
-            SELECTIVITY = atof(argv[iarg + 1]);
-        }
+    if (!strcmp(argv[iarg], "--selectivity")) { SELECTIVITY = atof(argv[iarg + 1]); }
 
-        if (!strcmp(argv[iarg], "--duplicate-build-keys")) {
-            IS_BUILD_TABLE_KEY_UNIQUE = false;
-        }
+    if (!strcmp(argv[iarg], "--duplicate-build-keys")) { IS_BUILD_TABLE_KEY_UNIQUE = false; }
 
-        if (!strcmp(argv[iarg], "--over-decomposition-factor")) {
-            OVER_DECOMPOSITION_FACTOR = atoi(argv[iarg + 1]);
-        }
+    if (!strcmp(argv[iarg], "--over-decomposition-factor")) {
+      OVER_DECOMPOSITION_FACTOR = atoi(argv[iarg + 1]);
     }
+  }
 }
 
-
-template<typename data_type>
-__global__ void
-verify_correctness(const data_type *data1, const data_type *data2, cudf::size_type size)
+template <typename data_type>
+__global__ void verify_correctness(const data_type *data1,
+                                   const data_type *data2,
+                                   cudf::size_type size)
 {
-    const cudf::size_type start_idx = threadIdx.x + blockDim.x * blockIdx.x;
-    const cudf::size_type stride = blockDim.x * gridDim.x;
+  const cudf::size_type start_idx = threadIdx.x + blockDim.x * blockIdx.x;
+  const cudf::size_type stride    = blockDim.x * gridDim.x;
 
-    for (cudf::size_type idx = start_idx; idx < size; idx += stride) {
-        assert(data1[idx] == data2[idx]);
-    }
+  for (cudf::size_type idx = start_idx; idx < size; idx += stride) {
+    assert(data1[idx] == data2[idx]);
+  }
 }
-
 
 int main(int argc, char *argv[])
 {
-    /* Initialize topology */
+  /* Initialize topology */
 
-    setup_topology(argc, argv);
+  setup_topology(argc, argv);
 
-    /* Parse command line arguments */
+  /* Parse command line arguments */
 
-    parse_command_line_arguments(argc, argv);
+  parse_command_line_arguments(argc, argv);
 
-    /* Initialize communicator */
+  /* Initialize communicator */
 
-    int mpi_rank;
-    int mpi_size;
-    MPI_CALL( MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank) );
-    MPI_CALL( MPI_Comm_size(MPI_COMM_WORLD, &mpi_size) );
+  int mpi_rank;
+  int mpi_size;
+  MPI_CALL(MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank));
+  MPI_CALL(MPI_Comm_size(MPI_COMM_WORLD, &mpi_size));
 
-    UCXCommunicator* communicator = initialize_ucx_communicator(false, 0, 0);
+  UCXCommunicator *communicator = initialize_ucx_communicator(false, 0, 0);
 
-    /* Initialize memory pool */
+  /* Initialize memory pool */
 
-    size_t free_memory, total_memory;
-    CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
-    const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
+  size_t free_memory, total_memory;
+  CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
+  const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
 
-    registered_memory_resource mr(communicator);
-    auto *pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
-        &mr, pool_size, pool_size);
-    rmm::mr::set_current_device_resource(pool_mr);
+  registered_memory_resource mr(communicator);
+  auto *pool_mr =
+    new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(&mr, pool_size, pool_size);
+  rmm::mr::set_current_device_resource(pool_mr);
 
-    /* Generate build table and probe table and compute reference solution */
+  /* Generate build table and probe table and compute reference solution */
 
-    std::unique_ptr<table> build;
-    std::unique_ptr<table> probe;
-    std::unique_ptr<table> reference;
+  std::unique_ptr<table> build;
+  std::unique_ptr<table> probe;
+  std::unique_ptr<table> reference;
 
-    cudf::table_view build_view;
-    cudf::table_view probe_view;
+  cudf::table_view build_view;
+  cudf::table_view probe_view;
 
-    if (mpi_rank == 0) {
-        KEY_T RAND_MAX_VAL = BUILD_TABLE_SIZE * 2;
+  if (mpi_rank == 0) {
+    KEY_T RAND_MAX_VAL = BUILD_TABLE_SIZE * 2;
 
-        std::tie(build, probe) = generate_build_probe_tables<KEY_T, PAYLOAD_T>(
-            BUILD_TABLE_SIZE, PROBE_TABLE_SIZE, SELECTIVITY, RAND_MAX_VAL, IS_BUILD_TABLE_KEY_UNIQUE
-        );
+    std::tie(build, probe) = generate_build_probe_tables<KEY_T, PAYLOAD_T>(
+      BUILD_TABLE_SIZE, PROBE_TABLE_SIZE, SELECTIVITY, RAND_MAX_VAL, IS_BUILD_TABLE_KEY_UNIQUE);
 
-        build_view = build->view();
-        probe_view = probe->view();
+    build_view = build->view();
+    probe_view = probe->view();
 
-        reference = cudf::inner_join(
-            build->view(), probe->view(),
-            {0}, {0}, {std::pair<cudf::size_type, cudf::size_type>(0, 0)}
-        );
+    reference = cudf::inner_join(
+      build->view(), probe->view(), {0}, {0}, {std::pair<cudf::size_type, cudf::size_type>(0, 0)});
+  }
+
+  std::unique_ptr<table> local_build = distribute_table(build_view, communicator);
+  std::unique_ptr<table> local_probe = distribute_table(probe_view, communicator);
+
+  /* Distributed join */
+
+  std::unique_ptr<table> join_result_all_ranks =
+    distributed_inner_join(local_build->view(),
+                           local_probe->view(),
+                           {0},
+                           {0},
+                           {std::pair<cudf::size_type, cudf::size_type>(0, 0)},
+                           communicator,
+                           OVER_DECOMPOSITION_FACTOR);
+
+  /* Send join result from all ranks to the root rank */
+
+  std::unique_ptr<table> join_result = collect_tables(join_result_all_ranks->view(), communicator);
+
+  /* Verify correctness */
+
+  if (mpi_rank == 0) {
+    // Although join_result and reference should contain the same table, rows may be reordered.
+    // Therefore, we first sort both tables and then compare
+
+    cudf::size_type nrows = reference->num_rows();
+    assert(join_result->num_rows() == nrows);
+
+    std::unique_ptr<table> join_sorted      = cudf::sort(join_result->view());
+    std::unique_ptr<table> reference_sorted = cudf::sort(reference->view());
+
+    // Get the number of thread blocks based on thread block size
+
+    const int block_size = 128;
+    int nblocks{-1};
+
+    CUDA_RT_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &nblocks, verify_correctness<KEY_T>, block_size, 0));
+
+    // There should be three columns in the result table. The first column is the joined key
+    // column. The second and third column comes from the payload column from the left and
+    // the right input table, respectively.
+
+    // Verify the first column (key column) is correct.
+
+    verify_correctness<KEY_T>
+      <<<nblocks, block_size>>>(join_sorted->view().column(0).head<KEY_T>(),
+                                reference_sorted->view().column(0).head<KEY_T>(),
+                                nrows);
+
+    // Verify the remaining two payload columns are correct.
+
+    for (cudf::size_type icol = 1; icol <= 2; icol++) {
+      verify_correctness<PAYLOAD_T>
+        <<<nblocks, block_size>>>(join_sorted->view().column(icol).head<PAYLOAD_T>(),
+                                  reference_sorted->view().column(icol).head<PAYLOAD_T>(),
+                                  nrows);
     }
 
-    std::unique_ptr<table> local_build = distribute_table(build_view, communicator);
-    std::unique_ptr<table> local_probe = distribute_table(probe_view, communicator);
+    CUDA_RT_CALL(cudaDeviceSynchronize());
+  }
 
-    /* Distributed join */
+  /* Cleanup */
 
-    std::unique_ptr<table> join_result_all_ranks = distributed_inner_join(
-        local_build->view(), local_probe->view(),
-        {0}, {0}, {std::pair<cudf::size_type, cudf::size_type>(0, 0)},
-        communicator, OVER_DECOMPOSITION_FACTOR
-    );
+  build.reset();
+  probe.reset();
+  reference.reset();
+  local_build.reset();
+  local_probe.reset();
+  join_result_all_ranks.reset();
+  join_result.reset();
+  CUDA_RT_CALL(cudaDeviceSynchronize());
 
-    /* Send join result from all ranks to the root rank */
+  delete pool_mr;
+  communicator->finalize();
+  delete communicator;
 
-    std::unique_ptr<table> join_result = collect_tables(
-        join_result_all_ranks->view(), communicator
-    );
+  if (mpi_rank == 0) { std::cerr << "Test case \"compare_against_shared\" passes successfully.\n"; }
 
-    /* Verify correctness */
-
-    if (mpi_rank == 0) {
-        // Although join_result and reference should contain the same table, rows may be reordered.
-        // Therefore, we first sort both tables and then compare
-
-        cudf::size_type nrows = reference->num_rows();
-        assert(join_result->num_rows() == nrows);
-
-        std::unique_ptr<table> join_sorted = cudf::sort(join_result->view());
-        std::unique_ptr<table> reference_sorted = cudf::sort(reference->view());
-
-        // Get the number of thread blocks based on thread block size
-
-        const int block_size = 128;
-        int nblocks {-1};
-
-        CUDA_RT_CALL(
-            cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-                &nblocks, verify_correctness<KEY_T>, block_size, 0
-            )
-        );
-
-        // There should be three columns in the result table. The first column is the joined key
-        // column. The second and third column comes from the payload column from the left and
-        // the right input table, respectively.
-
-        // Verify the first column (key column) is correct.
-
-        verify_correctness<KEY_T><<<nblocks, block_size>>>(
-            join_sorted->view().column(0).head<KEY_T>(),
-            reference_sorted->view().column(0).head<KEY_T>(),
-            nrows
-        );
-
-        // Verify the remaining two payload columns are correct.
-
-        for (cudf::size_type icol = 1; icol <= 2; icol++) {
-            verify_correctness<PAYLOAD_T><<<nblocks, block_size>>>(
-                join_sorted->view().column(icol).head<PAYLOAD_T>(),
-                reference_sorted->view().column(icol).head<PAYLOAD_T>(),
-                nrows
-            );
-        }
-
-        CUDA_RT_CALL( cudaDeviceSynchronize() );
-    }
-
-    /* Cleanup */
-
-    build.reset();
-    probe.reset();
-    reference.reset();
-    local_build.reset();
-    local_probe.reset();
-    join_result_all_ranks.reset();
-    join_result.reset();
-    CUDA_RT_CALL( cudaDeviceSynchronize() );
-
-    delete pool_mr;
-    communicator->finalize();
-    delete communicator;
-
-    if (mpi_rank == 0) {
-        std::cerr << "Test case \"compare_against_shared\" passes successfully.\n";
-    }
-
-    return 0;
+  return 0;
 }


### PR DESCRIPTION
This PR:
- copy `.clang-format` from cuDF repo
- add a script `run-clang-format.py` to run `clang-format` for all source files
- format all source files using `run-clang-format.py`

close #40 