### PR TITLE
nvcomp integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@ CUDA_CFLAGS=-I${CUDA_HOME}/include -arch=sm_70 --expt-extended-lambda --default-
 CUDA_LIBS=-L${CUDA_HOME}/lib64 -lcuda -lcudart
 NCCL_CFLAGS=-I${NCCL_HOME}/include
 NCCL_LIBS=-L${NCCL_HOME}/lib -lnccl
+NVCOMP_CFLAGS=-I${NVCOMP_HOME}/include
+NVCOMP_LIBS=-L${NVCOMP_HOME}/lib -lnvcomp
 
-CFLAGS=-g -std=c++14 ${NCCL_CFLAGS} ${MPI_CFLAGS} ${CUDA_CFLAGS} ${UCX_CFLAGS} ${CUDF_CFLAGS}
-LDFLAGS=${NCCL_LIBS} ${MPI_LIBS} ${CUDA_LIBS} ${UCX_LIBS} ${CUDF_LIBS}
+CFLAGS=-g -std=c++14 ${NCCL_CFLAGS} ${MPI_CFLAGS} ${CUDA_CFLAGS} ${UCX_CFLAGS} ${CUDF_CFLAGS} ${NVCOMP_CFLAGS}
+LDFLAGS=${NCCL_LIBS} ${MPI_LIBS} ${CUDA_LIBS} ${UCX_LIBS} ${CUDF_LIBS} ${NVCOMP_LIBS}
 
 generate_dataset=generate_dataset/generate_dataset.cuh generate_dataset/nvtx_helper.cuh
 src=src/comm.cuh src/error.cuh src/distribute_table.cuh src/distributed_join.cuh src/generate_table.cuh src/communicator.o src/registered_memory_resource.hpp

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ LDFLAGS=${NCCL_LIBS} ${MPI_LIBS} ${CUDA_LIBS} ${UCX_LIBS} ${CUDF_LIBS} ${NVCOMP_
 generate_dataset=generate_dataset/generate_dataset.cuh generate_dataset/nvtx_helper.cuh
 src=src/comm.cuh src/error.cuh src/distribute_table.cuh src/distributed_join.cuh src/generate_table.cuh src/communicator.o src/registered_memory_resource.hpp
 
-all: benchmark/distributed_join benchmark/all_to_all test/compare_against_shared test/prebuild test/buffer_communicator
+all: benchmark/distributed_join benchmark/all_to_all test/compare_against_single_gpu test/prebuild test/buffer_communicator
 
 benchmark/distributed_join: benchmark/distributed_join.cu $(generate_dataset) $(src)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o benchmark/distributed_join benchmark/distributed_join.cu src/communicator.o
@@ -27,8 +27,8 @@ benchmark/distributed_join: benchmark/distributed_join.cu $(generate_dataset) $(
 benchmark/all_to_all: benchmark/all_to_all.cu $(src)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o benchmark/all_to_all benchmark/all_to_all.cu src/communicator.o
 
-test/compare_against_shared: test/compare_against_shared.cu $(generate_dataset) $(src)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o test/compare_against_shared test/compare_against_shared.cu src/communicator.o
+test/compare_against_single_gpu: test/compare_against_single_gpu.cu $(generate_dataset) $(src)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o test/compare_against_single_gpu test/compare_against_single_gpu.cu src/communicator.o
 
 test/prebuild: test/prebuild.cu $(src)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o test/prebuild test/prebuild.cu src/communicator.o
@@ -40,4 +40,4 @@ src/communicator.o: src/communicator.h src/communicator.cu
 	$(CC) $(CFLAGS) $(LDFLAGS) -o src/communicator.o -c src/communicator.cu
 
 clean:
-	rm -f benchmark/distributed_join benchmark/all_to_all test/compare_against_shared test/prebuild src/communicator.o test/buffer_communicator
+	rm -f benchmark/distributed_join benchmark/all_to_all test/compare_against_single_gpu test/prebuild src/communicator.o test/buffer_communicator

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ src/
     distribute_table.cuh        Table distribution/collection between the root rank and all worker ranks.
     error.cuh                   Error checking macros.
 test/
-    buffer_communicator.cu      Test the correctness of the buffer communicator.
-    compare_against_shared.cu   Test the correctness of the distributed-join compared to shared-memory implementation on random tables.
-    prebuild.cu                 Test the correctness of the distributed-join compared to known solution.
+    buffer_communicator.cu          Test the correctness of the buffer communicator.
+    compare_against_single_gpu.cu   Test the correctness of the distributed-join compared to single-GPU implementation on random tables.
+    prebuild.cu                     Test the correctness of the distributed-join compared to known solution.
 ```
 
 ## Code formatting

--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -179,6 +179,10 @@ int main(int argc, char *argv[])
     throw std::runtime_error("Unknown communicator name");
   }
 
+  /* Warmup nvcomp */
+
+  if (COMPRESSION) { warmup_nvcomp(); }
+
   /* Generate build table and probe table on each rank */
 
   std::unique_ptr<cudf::table> left;

--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -52,6 +52,7 @@ static int OVER_DECOMPOSITION_FACTOR               = 1;
 static std::string COMMUNICATOR_NAME               = "UCX";
 static bool USE_BUFFER_COMMUNICATOR                = false;
 static int64_t COMMUNICATOR_BUFFER_SIZE            = 1'600'000'000LL;
+static bool COMPRESSION                            = false;
 
 void parse_command_line_arguments(int argc, char *argv[])
 {
@@ -79,6 +80,8 @@ void parse_command_line_arguments(int argc, char *argv[])
     if (!strcmp(argv[iarg], "--communicator")) { COMMUNICATOR_NAME = argv[iarg + 1]; }
 
     if (!strcmp(argv[iarg], "--use-buffer-communicator")) { USE_BUFFER_COMMUNICATOR = true; }
+
+    if (!strcmp(argv[iarg], "--compression")) { COMPRESSION = true; }
   }
 }
 
@@ -108,6 +111,7 @@ void report_configuration()
   std::cout << "Communicator: " << COMMUNICATOR_NAME << std::endl;
   if (COMMUNICATOR_NAME == "UCX")
     std::cout << "Buffer communicator: " << USE_BUFFER_COMMUNICATOR << std::endl;
+  std::cout << "Compression: " << COMPRESSION << std::endl;
   std::cout << "================================" << std::endl;
 }
 
@@ -225,7 +229,8 @@ int main(int argc, char *argv[])
                            {0},
                            {std::pair<cudf::size_type, cudf::size_type>(0, 0)},
                            communicator,
-                           OVER_DECOMPOSITION_FACTOR);
+                           OVER_DECOMPOSITION_FACTOR,
+                           COMPRESSION);
 
   MPI_Barrier(MPI_COMM_WORLD);
   double stop = MPI_Wtime();

--- a/src/comm.cuh
+++ b/src/comm.cuh
@@ -74,7 +74,7 @@ MPI_Datatype mpi_dtype_from_c_type()
  * in *data* destined for the current rank will not be copied.
  */
 void send_data_by_offset(const void *data,
-                         std::vector<int> const &offset,
+                         std::vector<int64_t> const &offset,
                          size_t item_size,
                          Communicator *communicator,
                          bool self_send = true)
@@ -86,7 +86,7 @@ void send_data_by_offset(const void *data,
     if (!self_send && itarget_rank == mpi_rank) continue;
 
     // calculate the number of elements to send
-    size_t count = offset[itarget_rank + 1] - offset[itarget_rank];
+    int64_t count = offset[itarget_rank + 1] - offset[itarget_rank];
 
     // calculate the starting address
     const void *start_addr = (void *)((char *)data + offset[itarget_rank] * item_size);
@@ -94,6 +94,16 @@ void send_data_by_offset(const void *data,
     // send buffer to the target rank
     communicator->send(start_addr, count, item_size, itarget_rank);
   }
+}
+
+void send_data_by_offset(const void *data,
+                         std::vector<int> const &offset,
+                         size_t item_size,
+                         Communicator *communicator,
+                         bool self_send = true)
+{
+  send_data_by_offset(
+    data, std::vector<int64_t>(offset.begin(), offset.end()), item_size, communicator, self_send);
 }
 
 /**

--- a/src/comm.cuh
+++ b/src/comm.cuh
@@ -79,8 +79,8 @@ void send_data_by_offset(const void *data,
                          Communicator *communicator,
                          bool self_send = true)
 {
-  int mpi_rank{communicator->mpi_rank};
-  int mpi_size{communicator->mpi_size};
+  int mpi_rank = communicator->mpi_rank;
+  int mpi_size = communicator->mpi_size;
 
   for (int itarget_rank = 0; itarget_rank < mpi_size; itarget_rank++) {
     if (!self_send && itarget_rank == mpi_rank) continue;
@@ -126,8 +126,8 @@ void recv_data_by_offset(void *data,
                          Communicator *communicator,
                          bool self_recv = true)
 {
-  int mpi_rank{communicator->mpi_rank};
-  int mpi_size{communicator->mpi_size};
+  int mpi_rank = communicator->mpi_rank;
+  int mpi_size = communicator->mpi_size;
 
   for (int isource_rank = 0; isource_rank < mpi_size; isource_rank++) {
     if (!self_recv && mpi_rank == isource_rank) continue;

--- a/src/distribute_table.cuh
+++ b/src/distribute_table.cuh
@@ -72,8 +72,8 @@ void distribute_cols(cudf::column_view global_col,
 {
   /* Get MPI information */
 
-  int mpi_rank{communicator->mpi_rank};
-  int mpi_size{communicator->mpi_size};
+  int mpi_rank = communicator->mpi_rank;
+  int mpi_size = communicator->mpi_size;
 
   std::size_t dtype_size = cudf::size_of(local_col.type());
 
@@ -123,8 +123,8 @@ std::unique_ptr<cudf::table> distribute_table(cudf::table_view global_table,
 {
   /* Get MPI information */
 
-  int mpi_rank{communicator->mpi_rank};
-  int mpi_size{communicator->mpi_size};
+  int mpi_rank               = communicator->mpi_rank;
+  int mpi_size               = communicator->mpi_size;
   MPI_Datatype mpi_size_type = mpi_dtype_from_c_type<cudf::size_type>();
 
   /* Broadcast global table size */
@@ -191,8 +191,8 @@ std::unique_ptr<cudf::table> distribute_table(cudf::table_view global_table,
  */
 std::unique_ptr<cudf::table> collect_tables(cudf::table_view table, Communicator *communicator)
 {
-  int mpi_rank{communicator->mpi_rank};
-  int mpi_size{communicator->mpi_size};
+  int mpi_rank = communicator->mpi_rank;
+  int mpi_size = communicator->mpi_size;
 
   int ncols = table.num_columns();
   int nrows = table.num_rows();

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,3 +1,3 @@
-compare_against_shared
+compare_against_single_gpu
 prebuild
 buffer_communicator

--- a/test/compare_against_shared.cu
+++ b/test/compare_against_shared.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <tuple>
@@ -37,32 +38,6 @@
 
 using cudf::table;
 
-#define KEY_T int
-#define PAYLOAD_T int
-
-static cudf::size_type BUILD_TABLE_SIZE = 1'000'000;
-static cudf::size_type PROBE_TABLE_SIZE = 5'000'000;
-static double SELECTIVITY               = 0.3;
-static bool IS_BUILD_TABLE_KEY_UNIQUE   = true;
-static int OVER_DECOMPOSITION_FACTOR    = 10;
-
-void parse_command_line_arguments(int argc, char *argv[])
-{
-  for (int iarg = 0; iarg < argc; iarg++) {
-    if (!strcmp(argv[iarg], "--build-table-nrows")) { BUILD_TABLE_SIZE = atoi(argv[iarg + 1]); }
-
-    if (!strcmp(argv[iarg], "--probe-table-nrows")) { PROBE_TABLE_SIZE = atoi(argv[iarg + 1]); }
-
-    if (!strcmp(argv[iarg], "--selectivity")) { SELECTIVITY = atof(argv[iarg + 1]); }
-
-    if (!strcmp(argv[iarg], "--duplicate-build-keys")) { IS_BUILD_TABLE_KEY_UNIQUE = false; }
-
-    if (!strcmp(argv[iarg], "--over-decomposition-factor")) {
-      OVER_DECOMPOSITION_FACTOR = atoi(argv[iarg + 1]);
-    }
-  }
-}
-
 template <typename data_type>
 __global__ void verify_correctness(const data_type *data1,
                                    const data_type *data2,
@@ -76,35 +51,19 @@ __global__ void verify_correctness(const data_type *data1,
   }
 }
 
-int main(int argc, char *argv[])
+template <typename KEY_T, typename PAYLOAD_T>
+void run_test(cudf::size_type build_table_size,
+              cudf::size_type probe_table_size,
+              double selectivity,
+              bool is_build_table_key_unique,
+              int over_decomposition_factor,
+              bool compression,
+              Communicator *communicator)
 {
-  /* Initialize topology */
-
-  setup_topology(argc, argv);
-
-  /* Parse command line arguments */
-
-  parse_command_line_arguments(argc, argv);
-
-  /* Initialize communicator */
-
   int mpi_rank;
   int mpi_size;
   MPI_CALL(MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank));
   MPI_CALL(MPI_Comm_size(MPI_COMM_WORLD, &mpi_size));
-
-  UCXCommunicator *communicator = initialize_ucx_communicator(false, 0, 0);
-
-  /* Initialize memory pool */
-
-  size_t free_memory, total_memory;
-  CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
-  const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
-
-  registered_memory_resource mr(communicator);
-  auto *pool_mr =
-    new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(&mr, pool_size, pool_size);
-  rmm::mr::set_current_device_resource(pool_mr);
 
   /* Generate build table and probe table and compute reference solution */
 
@@ -116,10 +75,10 @@ int main(int argc, char *argv[])
   cudf::table_view probe_view;
 
   if (mpi_rank == 0) {
-    KEY_T RAND_MAX_VAL = BUILD_TABLE_SIZE * 2;
+    KEY_T rand_max_val = build_table_size * 2;
 
     std::tie(build, probe) = generate_build_probe_tables<KEY_T, PAYLOAD_T>(
-      BUILD_TABLE_SIZE, PROBE_TABLE_SIZE, SELECTIVITY, RAND_MAX_VAL, IS_BUILD_TABLE_KEY_UNIQUE);
+      build_table_size, probe_table_size, selectivity, rand_max_val, is_build_table_key_unique);
 
     build_view = build->view();
     probe_view = probe->view();
@@ -140,7 +99,8 @@ int main(int argc, char *argv[])
                            {0},
                            {std::pair<cudf::size_type, cudf::size_type>(0, 0)},
                            communicator,
-                           OVER_DECOMPOSITION_FACTOR);
+                           over_decomposition_factor,
+                           compression);
 
   /* Send join result from all ranks to the root rank */
 
@@ -187,24 +147,58 @@ int main(int argc, char *argv[])
     }
 
     CUDA_RT_CALL(cudaDeviceSynchronize());
+
+    std::cerr << "Test case (" << build_table_size << "," << probe_table_size << "," << selectivity
+              << "," << is_build_table_key_unique << "," << over_decomposition_factor << ","
+              << compression << ") passes successfully.\n";
   }
+}
+
+int main(int argc, char *argv[])
+{
+  /* Initialize topology */
+
+  setup_topology(argc, argv);
+
+  /* Initialize communicator */
+
+  UCXCommunicator *communicator = initialize_ucx_communicator(false, 0, 0);
+
+  /* Initialize memory pool */
+
+  size_t free_memory, total_memory;
+  CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
+  const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
+
+  registered_memory_resource mr(communicator);
+  auto *pool_mr =
+    new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(&mr, pool_size, pool_size);
+  rmm::mr::set_current_device_resource(pool_mr);
+
+  /* run test */
+
+  run_test<int32_t, int32_t>(1'000'000, 5'000'000, 0.3, true, 10, false, communicator);
+  run_test<int32_t, int32_t>(1'000'000, 5'000'000, 0.3, true, 10, true, communicator);
+  run_test<int64_t, int64_t>(1'000'000, 5'000'000, 0.3, true, 10, false, communicator);
+  run_test<int64_t, int64_t>(1'000'000, 5'000'000, 0.3, true, 10, true, communicator);
+  run_test<int32_t, int32_t>(1'000'000, 5'000'000, 1.0, true, 10, false, communicator);
+  run_test<int32_t, int32_t>(1'000'000, 5'000'000, 1.0, true, 10, true, communicator);
+  run_test<int64_t, int64_t>(1'000'000, 5'000'000, 1.0, true, 10, false, communicator);
+  run_test<int64_t, int64_t>(1'000'000, 5'000'000, 1.0, true, 10, true, communicator);
+  run_test<int32_t, int32_t>(1'000'000, 1'000'000, 0.3, true, 10, false, communicator);
+  run_test<int32_t, int32_t>(1'000'000, 1'000'000, 0.3, true, 10, true, communicator);
+  run_test<int64_t, int64_t>(1'000'000, 1'000'000, 0.3, true, 10, false, communicator);
+  run_test<int64_t, int64_t>(1'000'000, 1'000'000, 0.3, true, 10, true, communicator);
+  run_test<int32_t, int32_t>(1'000'000, 5'000'000, 0.3, true, 1, false, communicator);
+  run_test<int32_t, int32_t>(1'000'000, 5'000'000, 0.3, true, 1, true, communicator);
+  run_test<int64_t, int64_t>(1'000'000, 5'000'000, 0.3, true, 1, false, communicator);
+  run_test<int64_t, int64_t>(1'000'000, 5'000'000, 0.3, true, 1, true, communicator);
 
   /* Cleanup */
-
-  build.reset();
-  probe.reset();
-  reference.reset();
-  local_build.reset();
-  local_probe.reset();
-  join_result_all_ranks.reset();
-  join_result.reset();
-  CUDA_RT_CALL(cudaDeviceSynchronize());
 
   delete pool_mr;
   communicator->finalize();
   delete communicator;
-
-  if (mpi_rank == 0) { std::cerr << "Test case \"compare_against_shared\" passes successfully.\n"; }
 
   return 0;
 }

--- a/test/compare_against_single_gpu.cu
+++ b/test/compare_against_single_gpu.cu
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
+/*
+This test case compares the result of distributed join on multiple GPUs to the result of
+cudf::inner_join on a single GPU.
+
+Specifically, it follows the following steps:
+1. The root rank constructs a random build table and a random probe table.
+2. The root rank runs cudf::inner_join on the newly constructed tables.
+3. The root rank distributes the build and probe table across all ranks.
+4. All ranks run distibuted join collectively.
+5. Each rank sends the distributed join result to the root rank.
+6. The root rank assembles the received results into a single table and compares it to the result of
+step 2.
+*/
+
 #include <cstdint>
 #include <iostream>
 #include <memory>

--- a/test/prebuild.cu
+++ b/test/prebuild.cu
@@ -80,6 +80,8 @@ void run_test(cudf::size_type size,  // must be a multiple of 5
               bool compression,
               Communicator *communicator)
 {
+  assert(size % 5 == 0);
+
   int mpi_rank;
   MPI_CALL(MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank));
 


### PR DESCRIPTION
This PR add an argument `compression` to `distributed_inner_join`, such that if it is set to `true`, the input buffers will be compressed before sending to remote GPUs, and decompressed after receiving. The compression and decompression are performed by `nvcomp`. Only cascaded compression on integer columns will be supported.