### PR TITLE
Remove unnecessary calls to std::move

### DIFF
--- a/src/generate_table.cuh
+++ b/src/generate_table.cuh
@@ -70,13 +70,13 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<table>> generate_build_probe_t
 
   constexpr cudf::data_type payload_type = cudf::data_type(cudf::type_to_id<PAYLOAD_T>());
 
-  build.push_back(std::move(cudf::make_numeric_column(key_type, build_table_nrows)));
+  build.push_back(cudf::make_numeric_column(key_type, build_table_nrows));
 
-  build.push_back(std::move(cudf::make_numeric_column(payload_type, build_table_nrows)));
+  build.push_back(cudf::make_numeric_column(payload_type, build_table_nrows));
 
-  probe.push_back(std::move(cudf::make_numeric_column(key_type, probe_table_nrows)));
+  probe.push_back(cudf::make_numeric_column(key_type, probe_table_nrows));
 
-  probe.push_back(std::move(cudf::make_numeric_column(payload_type, probe_table_nrows)));
+  probe.push_back(cudf::make_numeric_column(payload_type, probe_table_nrows));
 
   // Generate build and probe table data
 


### PR DESCRIPTION
std::move is only needed if the returned value from a function doesn't implement move semantics.  But `cudf::make_numeric_column` returns a `std::unique_ptr<>` and `std::unique_ptr`, like everything in the standard library, already has move semantics.

Using std::move where it isn't necessary can prevent compiler optimizations.