### PR TITLE
Improve all-to-all benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,14 @@ means smaller batch size. `1` means no overlap. Default: `1`.
 
 This option can be either "UCX" or "NCCL", which controls what communicator to use. Default: `UCX`.
 
-**--use-buffer-communicator**
+**--registration-method [STR]**
 
-If this option is specified, UCX communication goes through a pre-registered staging buffer. This
-option is recommeneded for IB system to reduce registration overhead.
+If the UCX communicator is selected, this option can be either "none", "preregistered" or "buffer",
+to control how registration is performed for GPUDirect RDMA.
+- "none": No preregistration.
+- "preregistered": The whole RMM memory pool will be preregistered.
+- "buffer": Preregister a set of communication buffers. The communication in distributed join will
+go through these buffers.
 
 ## Running
 

--- a/benchmark/distributed_join.cu
+++ b/benchmark/distributed_join.cu
@@ -50,7 +50,7 @@ static double SELECTIVITY                          = 0.3;
 static bool IS_BUILD_TABLE_KEY_UNIQUE              = true;
 static int OVER_DECOMPOSITION_FACTOR               = 1;
 static std::string COMMUNICATOR_NAME               = "UCX";
-static bool USE_BUFFER_COMMUNICATOR                = false;
+static std::string REGISTRATION_METHOD             = "preregistered";
 static int64_t COMMUNICATOR_BUFFER_SIZE            = 1'600'000'000LL;
 
 void parse_command_line_arguments(int argc, char *argv[])
@@ -78,7 +78,7 @@ void parse_command_line_arguments(int argc, char *argv[])
 
     if (!strcmp(argv[iarg], "--communicator")) { COMMUNICATOR_NAME = argv[iarg + 1]; }
 
-    if (!strcmp(argv[iarg], "--use-buffer-communicator")) { USE_BUFFER_COMMUNICATOR = true; }
+    if (!strcmp(argv[iarg], "--registration-method")) { REGISTRATION_METHOD = argv[iarg + 1]; }
   }
 }
 
@@ -107,7 +107,7 @@ void report_configuration()
   std::cout << "Over-decomposition factor: " << OVER_DECOMPOSITION_FACTOR << std::endl;
   std::cout << "Communicator: " << COMMUNICATOR_NAME << std::endl;
   if (COMMUNICATOR_NAME == "UCX")
-    std::cout << "Buffer communicator: " << USE_BUFFER_COMMUNICATOR << std::endl;
+    std::cout << "Registration method: " << REGISTRATION_METHOD << std::endl;
   std::cout << "================================" << std::endl;
 }
 
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
   Communicator *communicator{nullptr};
   // `mr` holds reference to the registered memory resource, and *nullptr* if registered memory
   // resource is not used.
-  registered_memory_resource *mr{nullptr};
+  registered_memory_resource *registered_mr{nullptr};
   // pool_mr need to live on heap because for registered memory resources, the memory pool needs
   // to deallocated before UCX cleanup, which can be achieved by calling the destructor of
   // `poll_mr`.
@@ -146,31 +146,40 @@ int main(int argc, char *argv[])
   CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
   const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
 
-  if (COMMUNICATOR_NAME == "UCX" && USE_BUFFER_COMMUNICATOR) {
-    // For UCX with buffer communicator, a memory pool is first constructed so that the
-    // communication buffers will be allocated in memory pool.
-    pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
-      rmm::mr::get_current_device_resource(), pool_size, pool_size);
-    rmm::mr::set_current_device_resource(pool_mr);
-    // *2 because buffers are needed for both sends and receives
-    const int num_comm_buffers = 2 * mpi_size;
-    communicator               = initialize_ucx_communicator(
-      true, num_comm_buffers, COMMUNICATOR_BUFFER_SIZE / num_comm_buffers - 100'000LL);
-  } else if (COMMUNICATOR_NAME == "UCX" && !USE_BUFFER_COMMUNICATOR) {
-    // For UCX with preregistered memory pool, a communicator is first constructed so that
-    // `registered_memory_resource` can use the communicator for buffer registrations.
-    UCXCommunicator *ucx_communicator = initialize_ucx_communicator(false, 0, 0);
-    communicator                      = ucx_communicator;
-    mr                                = new registered_memory_resource(ucx_communicator);
-    pool_mr =
-      new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(mr, pool_size, pool_size);
-    rmm::mr::set_current_device_resource(pool_mr);
-  } else if (COMMUNICATOR_NAME == "NCCL") {
+  if (COMMUNICATOR_NAME == "NCCL") {
     communicator = new NCCLCommunicator;
     communicator->initialize();
     pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
       rmm::mr::get_current_device_resource(), pool_size, pool_size);
     rmm::mr::set_current_device_resource(pool_mr);
+  } else if (COMMUNICATOR_NAME == "UCX") {
+    if (REGISTRATION_METHOD == "buffer") {
+      // For UCX with buffer communicator, a memory pool is first constructed so that the
+      // communication buffers will be allocated in memory pool.
+      pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
+        rmm::mr::get_current_device_resource(), pool_size, pool_size);
+      rmm::mr::set_current_device_resource(pool_mr);
+      // *2 because buffers are needed for both sends and receives
+      const int num_comm_buffers = 2 * mpi_size;
+      communicator               = initialize_ucx_communicator(
+        true, num_comm_buffers, COMMUNICATOR_BUFFER_SIZE / num_comm_buffers - 100'000LL);
+    } else if (REGISTRATION_METHOD == "preregistered") {
+      // For UCX with preregistered memory pool, a communicator is first constructed so that
+      // `registered_memory_resource` can use the communicator for buffer registrations.
+      UCXCommunicator *ucx_communicator = initialize_ucx_communicator(false, 0, 0);
+      communicator                      = ucx_communicator;
+      registered_mr                     = new registered_memory_resource(ucx_communicator);
+      pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
+        registered_mr, pool_size, pool_size);
+      rmm::mr::set_current_device_resource(pool_mr);
+    } else if (REGISTRATION_METHOD == "none") {
+      communicator = initialize_ucx_communicator(false, 0, 0);
+      pool_mr      = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
+        rmm::mr::get_current_device_resource(), pool_size, pool_size);
+      rmm::mr::set_current_device_resource(pool_mr);
+    } else {
+      throw std::runtime_error("Unknown registration method");
+    }
   } else {
     throw std::runtime_error("Unknown communicator name");
   }
@@ -239,17 +248,19 @@ int main(int argc, char *argv[])
   join_result.reset();
   CUDA_RT_CALL(cudaDeviceSynchronize());
 
-  if (USE_BUFFER_COMMUNICATOR) {
+  if (COMMUNICATOR_NAME == "UCX" && REGISTRATION_METHOD == "buffer") {
     // When finalizing buffer communicator, communication buffers need be deallocated, so
     // `finalize` needs to be called before the memory pool is deleted.
     communicator->finalize();
     delete pool_mr;
-    delete mr;
+    delete registered_mr;
   } else {
     // For registered memory resouce, the memory pool needs to be deleted before finalizing
     // the communicator, so that all buffers can be deregistered through UCX.
+    // For every other scenario, the order of deleting memory pool and finalizing the communicator
+    // does not matter, and we just choose this path.
     delete pool_mr;
-    delete mr;
+    delete registered_mr;
     communicator->finalize();
   }
 

--- a/benchmark/run_sample.sh
+++ b/benchmark/run_sample.sh
@@ -5,7 +5,7 @@ lrank=$OMPI_COMM_WORLD_LOCAL_RANK
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-# APP="benchmark/all_to_all --use-buffer-communicator --warm-up --repeat 1"
+# APP="benchmark/all_to_all --repeat 1"
 APP="benchmark/distributed_join"
 
 # this is the list of GPUs we have

--- a/src/topology.cuh
+++ b/src/topology.cuh
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-#include <mpi.h>
-#include <iostream>
-
 #include "error.cuh"
+#include "registered_memory_resource.hpp"
+
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
+
+#include <mpi.h>
+
+#include <iostream>
 
 void setup_topology(int argc, char *argv[])
 {
@@ -35,4 +40,103 @@ void setup_topology(int argc, char *argv[])
   CUDA_RT_CALL(cudaSetDevice(current_device));
   std::cout << "Rank " << mpi_rank << " select " << current_device << "/" << device_count << " GPU"
             << std::endl;
+}
+
+/**
+ * Setup RMM memory pool and communicator.
+ *
+ * This function will set the current device's memory pool. The memory pool and communicator
+ * initialized in this function can be destroyed by *destroy_memory_pool_and_communicator*.
+ *
+ * @param[out]: communicator Communicator to be constructed.
+ * @param[out]: registered_mr If the memory pool needs to be preregistered, this argument holds
+ * pointer to the registered memory resource. If not preregistered, this argument will be *nullptr*.
+ * @param[out]: pool_mr RMM memory resource for memory pool.
+ * @param[in]: communicator_name Can be either "NCCL" or "UCX".
+ * @param[in]: registration_method If using UCX communicator, this argument can be either "none",
+ * "buffer" or "preregistered".
+ * @param[in]: communicator_buffer_size If the registration_method is set to "buffer", this argument
+ * controls the size of the communication buffer used by the communicator.
+ */
+void setup_memory_pool_and_communicator(
+  Communicator *&communicator,
+  registered_memory_resource *&registered_mr,
+  rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> *&pool_mr,
+  std::string communicator_name,
+  std::string registration_method,
+  int64_t communicator_buffer_size)
+{
+  int mpi_size;
+  MPI_CALL(MPI_Comm_size(MPI_COMM_WORLD, &mpi_size));
+
+  registered_mr = nullptr;
+
+  // Calculate the memory pool size
+  size_t free_memory, total_memory;
+  CUDA_RT_CALL(cudaMemGetInfo(&free_memory, &total_memory));
+  const size_t pool_size = free_memory - 5LL * (1LL << 29);  // free memory - 500MB
+
+  if (communicator_name == "NCCL") {
+    communicator = new NCCLCommunicator;
+    communicator->initialize();
+    pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
+      rmm::mr::get_current_device_resource(), pool_size, pool_size);
+    rmm::mr::set_current_device_resource(pool_mr);
+  } else if (communicator_name == "UCX") {
+    if (registration_method == "buffer") {
+      // For UCX with buffer communicator, a memory pool is first constructed so that the
+      // communication buffers will be allocated in memory pool.
+      pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
+        rmm::mr::get_current_device_resource(), pool_size, pool_size);
+      rmm::mr::set_current_device_resource(pool_mr);
+      // *2 because buffers are needed for both sends and receives
+      const int num_comm_buffers = 2 * mpi_size;
+      communicator               = initialize_ucx_communicator(
+        true, num_comm_buffers, communicator_buffer_size / num_comm_buffers - 100'000LL);
+    } else if (registration_method == "preregistered") {
+      // For UCX with preregistered memory pool, a communicator is first constructed so that
+      // `registered_memory_resource` can use the communicator for buffer registrations.
+      UCXCommunicator *ucx_communicator = initialize_ucx_communicator(false, 0, 0);
+      communicator                      = ucx_communicator;
+      registered_mr                     = new registered_memory_resource(ucx_communicator);
+      pool_mr = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
+        registered_mr, pool_size, pool_size);
+      rmm::mr::set_current_device_resource(pool_mr);
+    } else if (registration_method == "none") {
+      communicator = initialize_ucx_communicator(false, 0, 0);
+      pool_mr      = new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(
+        rmm::mr::get_current_device_resource(), pool_size, pool_size);
+      rmm::mr::set_current_device_resource(pool_mr);
+    } else {
+      throw std::runtime_error("Unknown registration method");
+    }
+  } else {
+    throw std::runtime_error("Unknown communicator name");
+  }
+}
+
+void destroy_memory_pool_and_communicator(
+  Communicator *communicator,
+  registered_memory_resource *registered_mr,
+  rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> *pool_mr,
+  std::string communicator_name,
+  std::string registration_method)
+{
+  if (communicator_name == "UCX" && registration_method == "buffer") {
+    // When finalizing buffer communicator, communication buffers need be deallocated, so
+    // `finalize` needs to be called before the memory pool is deleted.
+    communicator->finalize();
+    delete pool_mr;
+    delete registered_mr;
+  } else {
+    // For registered memory resouce, the memory pool needs to be deleted before finalizing
+    // the communicator, so that all buffers can be deregistered through UCX.
+    // For every other scenario, the order of deleting memory pool and finalizing the communicator
+    // does not matter, and we just choose this path.
+    delete pool_mr;
+    delete registered_mr;
+    communicator->finalize();
+  }
+
+  delete communicator;
 }


### PR DESCRIPTION
This PR improves all-to-all benchmark to have a series of runs with various sizes.

Sample output:
```
Size (MB): 1, Elasped time (s): 0.000176531, Bandwidth per GPU (GB/s): 16.9942
Size (MB): 2, Elasped time (s): 0.000267493, Bandwidth per GPU (GB/s): 22.4305
Size (MB): 4, Elasped time (s): 0.000302923, Bandwidth per GPU (GB/s): 39.614
Size (MB): 8, Elasped time (s): 0.000512558, Bandwidth per GPU (GB/s): 46.824
Size (MB): 16, Elasped time (s): 0.000820293, Bandwidth per GPU (GB/s): 58.5157
Size (MB): 32, Elasped time (s): 0.00148969, Bandwidth per GPU (GB/s): 64.4429
Size (MB): 64, Elasped time (s): 0.0027744, Bandwidth per GPU (GB/s): 69.2042
Size (MB): 128, Elasped time (s): 0.00543221, Bandwidth per GPU (GB/s): 70.6895
Size (MB): 256, Elasped time (s): 0.0106805, Bandwidth per GPU (GB/s): 71.9069
Size (MB): 512, Elasped time (s): 0.0212418, Bandwidth per GPU (GB/s): 72.3102
Size (MB): 1024, Elasped time (s): 0.0423483, Bandwidth per GPU (GB/s): 72.5413
Size (MB): 2048, Elasped time (s): 0.0845411, Bandwidth per GPU (GB/s): 72.6748
Size (MB): 4096, Elasped time (s): 0.168941, Bandwidth per GPU (GB/s): 72.7353
```

This PR is built on top of #49 